### PR TITLE
docs(D1): 修正 Python 版本要求为 3.11.x

### DIFF
--- a/docs/dev/D1 课程稿：大模型 API 工程化基础.md
+++ b/docs/dev/D1 课程稿：大模型 API 工程化基础.md
@@ -421,7 +421,9 @@ if response.tool_calls:
 python3 --version
 ```
 
-如果能输出版本号（如 `Python 3.10.x`），就说明已经有了。如果没有，需要先去 [python.org](https://www.python.org/downloads/) 下载安装。
+如果能输出版本号（如 `Python 3.11.x`），就说明已经有了。如果没有，需要先去 [python.org](https://www.python.org/downloads/) 下载安装。
+
+> ⚠️ 本课程后续会用到 `pyseekdb`，它要求 **Python ≥ 3.11**，请确保你的 Python 版本不低于 3.11，否则安装会失败。
 
 
 


### PR DESCRIPTION
## Summary
- 修正 D1 课程稿中 Python 版本要求：`3.10.x` → `3.11.x`
- 在版本检查处补充提示，说明 `pyseekdb` 要求 Python ≥ 3.11，避免读者在后续课程中遇到安装失败

## Background
`pyseekdb` 最低要求 Python 3.11.x，原文档写 3.10.x 会导致按文档操作的读者在安装 `pyseekdb` 时报错。

Closes #2

## Test plan
- [x] 文档渲染正常
- [x] 改动范围仅限 D1 课程稿一处

🤖 Generated with [Claude Code](https://claude.com/claude-code)