### PR TITLE
feat: 新增扩展篇 X1-X5 招募页并接入站点侧边栏

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,7 @@ chore: <工程/基建说明>            # CI、依赖、脚本
 
 ## 五、参与方式总览
 
-1. **提 Issue 参与讨论**：先开 Issue 说明你的建议、需求或共建思路（可用下方 Issue 模板）。
+1. **提 Issue 参与讨论**：先开 Issue 说明你的建议、需求或共建思路（在 [New Issue](https://github.com/datawhalechina/easy-data-x-ai/issues/new/choose) 页选择对应的 Issue 模板）。
 2. **认领任务提 PR**：在对应 Issue 下留言认领，在章节文件中调整、完善、补充，完成后提 PR。
 3. **贡献扩展篇**：在 `docs/extra/` 下独立创建新章节（先开 Issue 对齐大纲）。
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -73,6 +73,17 @@ export default defineConfig({
           { text: 'D4：Agent 开发与记忆系统', link: '/dev/D4 课程稿：Agent 开发与记忆系统' },
           { text: 'D5：课程总结', link: '/dev/D5 课程稿：课程总结' }
         ]
+      },
+      {
+        text: '第四章：扩展篇（共建招募中）',
+        collapsed: false,
+        items: [
+          { text: 'X1：探究 AI Agent 记忆系统', link: '/extra/X1 探究 AI Agent 记忆系统：从遗忘曲线到永久记忆' },
+          { text: 'X2：多 Skill 与上下文工程', link: '/extra/X2 多 Skill 给上下文工程带来的麻烦：如何应对 Agent「爆上下文」' },
+          { text: 'X3：混合检索与统一数据基座', link: '/extra/X3 从零到一上手混合检索：AI Native 统一数据基座实战' },
+          { text: 'X4：数据湖库与多模数据降本', link: '/extra/X4 海量 AI Agent 多模数据降本：数据湖库登场' },
+          { text: 'X5：由你来定！', link: '/extra/X5 由你来定' }
+        ]
       }
     ],
 

--- a/docs/extra/X1 探究 AI Agent 记忆系统：从遗忘曲线到永久记忆.md
+++ b/docs/extra/X1 探究 AI Agent 记忆系统：从遗忘曲线到永久记忆.md
@@ -1,0 +1,30 @@
+---
+title: X1 探究 AI Agent 记忆系统：从遗忘曲线到永久记忆
+---
+
+# X1：探究 AI Agent 记忆系统 —— 从遗忘曲线到永久记忆
+
+::: warning 🚧 本章节正在招募共建中
+这是《Easy Data x AI》的**扩展篇（Extra-Chapter）**，目前尚未成稿，正在面向社区招募共建者一起撰写。欢迎你来认领！
+:::
+
+## 这一章打算讲什么
+
+| | |
+| --- | --- |
+| **热点趋势** | AI 记忆 |
+| **关联正文** | 道篇 P3、术篇 D4（记忆系统） |
+| **共建入口** | 多 Agent 记忆冲突解决（对应共建任务 #1 / #2 / #3） |
+
+> 在课程正文 P3 / D4 的记忆系统基础上，进一步探究：记忆如何随时间衰减、如何在多 Agent 间隔离与共享、新旧记忆冲突如何解决，直到走向「永久记忆」。
+>
+> 详细大纲待共建者与维护者一起对齐后补充。
+
+## 如何参与共建
+
+本章节欢迎你来认领、撰写。完整的参与方式、任务列表与激励机制，请阅读：
+
+👉 **[贡献指南 CONTRIBUTING.md](https://github.com/datawhalechina/easy-data-x-ai/blob/main/CONTRIBUTING.md)**
+
+- 扩展篇方向较大，**认领前请先开 [Issue](https://github.com/datawhalechina/easy-data-x-ai/issues) 对齐内容大纲**。
+- 完成后提交 PR，即可登上仓库[贡献者墙](https://github.com/datawhalechina/easy-data-x-ai#-贡献者墙)并获得社区激励。

--- a/docs/extra/X2 多 Skill 给上下文工程带来的麻烦：如何应对 Agent「爆上下文」.md
+++ b/docs/extra/X2 多 Skill 给上下文工程带来的麻烦：如何应对 Agent「爆上下文」.md
@@ -1,0 +1,30 @@
+---
+title: X2 多 Skill 给上下文工程带来的麻烦：如何应对 Agent「爆上下文」
+---
+
+# X2：多 Skill 给上下文工程带来的麻烦 —— 如何应对 Agent「爆上下文」
+
+::: warning 🚧 本章节正在招募共建中
+这是《Easy Data x AI》的**扩展篇（Extra-Chapter）**，目前尚未成稿，正在面向社区招募共建者一起撰写。欢迎你来认领！
+:::
+
+## 这一章打算讲什么
+
+| | |
+| --- | --- |
+| **热点趋势** | 多 Skill / 上下文工程 |
+| **关联正文** | 道篇 P4（Skill 与知识管理） |
+| **共建入口** | Skill 设计规范（对应共建任务 #4 / #5） |
+
+> 在课程正文 P4 的基础上，进一步探究：当 Skill 越来越多、全量注入上下文导致「爆上下文」时，如何用结构化存储 + 按需检索来管理 Skill，并给出一套可复用的 Skill 设计规范。
+>
+> 详细大纲待共建者与维护者一起对齐后补充。
+
+## 如何参与共建
+
+本章节欢迎你来认领、撰写。完整的参与方式、任务列表与激励机制，请阅读：
+
+👉 **[贡献指南 CONTRIBUTING.md](https://github.com/datawhalechina/easy-data-x-ai/blob/main/CONTRIBUTING.md)**
+
+- 扩展篇方向较大，**认领前请先开 [Issue](https://github.com/datawhalechina/easy-data-x-ai/issues) 对齐内容大纲**。
+- 完成后提交 PR，即可登上仓库[贡献者墙](https://github.com/datawhalechina/easy-data-x-ai#-贡献者墙)并获得社区激励。

--- a/docs/extra/X3 从零到一上手混合检索：AI Native 统一数据基座实战.md
+++ b/docs/extra/X3 从零到一上手混合检索：AI Native 统一数据基座实战.md
@@ -1,0 +1,30 @@
+---
+title: X3 从零到一上手混合检索：AI Native 统一数据基座实战
+---
+
+# X3：从零到一上手混合检索 —— AI Native 统一数据基座实战
+
+::: warning 🚧 本章节正在招募共建中
+这是《Easy Data x AI》的**扩展篇（Extra-Chapter）**，目前尚未成稿，正在面向社区招募共建者一起撰写。欢迎你来认领！
+:::
+
+## 这一章打算讲什么
+
+| | |
+| --- | --- |
+| **热点趋势** | Agentic RAG / 混合检索 |
+| **关联正文** | 道篇 P2、术篇 D3（RAG 与混合检索） |
+| **共建入口** | 扩充 RAG 评测数据集（对应共建任务 #11 / #12） |
+
+> 在课程正文 P2 / D3 的基础上，进一步带读者从零搭建一套基于 AI Native 数据库的统一数据基座，跑通混合检索（向量 + 全文），并用更丰富的评测数据集量化「混合检索 vs 纯向量检索」的效果差异。
+>
+> 详细大纲待共建者与维护者一起对齐后补充。
+
+## 如何参与共建
+
+本章节欢迎你来认领、撰写。完整的参与方式、任务列表与激励机制，请阅读：
+
+👉 **[贡献指南 CONTRIBUTING.md](https://github.com/datawhalechina/easy-data-x-ai/blob/main/CONTRIBUTING.md)**
+
+- 扩展篇方向较大，**认领前请先开 [Issue](https://github.com/datawhalechina/easy-data-x-ai/issues) 对齐内容大纲**。
+- 完成后提交 PR，即可登上仓库[贡献者墙](https://github.com/datawhalechina/easy-data-x-ai#-贡献者墙)并获得社区激励。

--- a/docs/extra/X4 海量 AI Agent 多模数据降本：数据湖库登场.md
+++ b/docs/extra/X4 海量 AI Agent 多模数据降本：数据湖库登场.md
@@ -1,0 +1,30 @@
+---
+title: X4 海量 AI Agent 多模数据降本：数据湖库登场
+---
+
+# X4：海量 AI Agent 多模数据降本 —— 数据湖库登场
+
+::: warning 🚧 本章节正在招募共建中
+这是《Easy Data x AI》的**扩展篇（Extra-Chapter）**，目前尚未成稿，正在面向社区招募共建者一起撰写。欢迎你来认领！
+:::
+
+## 这一章打算讲什么
+
+| | |
+| --- | --- |
+| **热点趋势** | 数据湖库 × AI |
+| **关联正文** | 术篇 D2、D4（数据层与记忆存储） |
+| **共建入口** | 开源「湖到 RAG」教程（对应共建任务 #14 / #15） |
+
+> 在课程正文 D2 / D4 的基础上，进一步探究：当 AI Agent 产生的多模数据规模变大时，如何用数据湖库做冷热分层、降本存储，并打通「从数据湖到 RAG」的完整链路。
+>
+> 详细大纲待共建者与维护者一起对齐后补充。
+
+## 如何参与共建
+
+本章节欢迎你来认领、撰写。完整的参与方式、任务列表与激励机制，请阅读：
+
+👉 **[贡献指南 CONTRIBUTING.md](https://github.com/datawhalechina/easy-data-x-ai/blob/main/CONTRIBUTING.md)**
+
+- 扩展篇方向较大，**认领前请先开 [Issue](https://github.com/datawhalechina/easy-data-x-ai/issues) 对齐内容大纲**。
+- 完成后提交 PR，即可登上仓库[贡献者墙](https://github.com/datawhalechina/easy-data-x-ai#-贡献者墙)并获得社区激励。

--- a/docs/extra/X5 由你来定.md
+++ b/docs/extra/X5 由你来定.md
@@ -1,0 +1,30 @@
+---
+title: X5 由你来定！
+---
+
+# X5：由你来定！
+
+::: warning 🚧 本章节正在招募共建中
+这是《Easy Data x AI》预留给社区的**开放扩展篇（Extra-Chapter）**——主题尚未确定，等你来定义！
+:::
+
+## 这一章可以是什么
+
+| | |
+| --- | --- |
+| **热点趋势** | 由你来定 |
+| **关联正文** | 不限 |
+| **共建入口** | 你提出的任何与「Data × AI」相关的选题 |
+
+> 只要是和「Agent 背后的数据层」相关、对学习者有价值的主题——无论是一个新的实战案例、一次有意思的对比实验，还是一个被正文漏掉的关键场景——都欢迎你提出来，把它变成 X5。
+>
+> 先开 Issue 说说你的想法，和维护者对齐后即可开工。
+
+## 如何参与共建
+
+本章节欢迎你来定义、撰写。完整的参与方式、任务列表与激励机制，请阅读：
+
+👉 **[贡献指南 CONTRIBUTING.md](https://github.com/datawhalechina/easy-data-x-ai/blob/main/CONTRIBUTING.md)**
+
+- **认领前请先开 [Issue](https://github.com/datawhalechina/easy-data-x-ai/issues) 提出你的选题与大纲**。
+- 完成后提交 PR，即可登上仓库[贡献者墙](https://github.com/datawhalechina/easy-data-x-ai#-贡献者墙)并获得社区激励。


### PR DESCRIPTION
## Summary

- `docs/extra/` 新增 X1–X5 五个「招募共建中」占位页面，每页含章节定位、关联正文、共建入口及指向 CONTRIBUTING.md 的链接
- VitePress 侧边栏新增「第四章：扩展篇（共建招募中）」，上线后在站点左侧可见
- CONTRIBUTING 修正「下方 Issue 模板」措辞，改为指向 New Issue 选择页

## Test plan

- [ ] 站点左侧导航出现「扩展篇」章节，X1–X5 可正常打开
- [ ] 各页 CONTRIBUTING 链接可达

🤖 Generated with [Claude Code](https://claude.com/claude-code)