### PR TITLE
docs: 移除模型算力支持章节并调整维护者信息

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,47 +143,24 @@ python3 d1_1_base.py
 
 ---
 
-## 模型算力支持
-
-<table>
-<tr>
-<td width="180" align="center" valign="middle">
-<a href="https://cloud.siliconflow.cn/i/Fq9zUwPf" target="_blank" rel="noopener">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="docs/public/images/sponsors/siliconflow-dark.svg" />
-    <img src="docs/public/images/sponsors/siliconflow.svg" alt="SiliconFlow 硅基流动" width="150" />
-  </picture>
-</a>
-</td>
-<td valign="middle">
-本课程的模型算力由 <strong><a href="https://cloud.siliconflow.cn/i/Fq9zUwPf">硅基流动（SiliconFlow）</a></strong> 支持。硅基流动是一站式大模型云服务平台，基于自研推理引擎实现大模型高效推理加速，提供高效能、低成本的多品类 AI 模型服务，让开发者和企业聚焦产品创新，无须担心大规模推广带来的高昂算力成本。
-</td>
-</tr>
-</table>
-
-- 🎁 **新用户福利**：通过 [课程专属注册链接](https://cloud.siliconflow.cn/i/Fq9zUwPf) 注册并完成实名认证，即可获得 **16 元全平台通用代金券**，可用于平台上百余种模型的调用，足够跑通本课程的全部示例。
-- 🧪 **实验配额补贴池**：用上面的链接注册时，作者也会获得平台返利。这部分返利会**全额回馈给学员**——汇集成一个「实验配额补贴池」：跟着课程做实验、复现示例时如果额度不够用，可以[联系作者](https://space.bilibili.com/3546900567427713)申请额外的算力配额补贴，把福利转回给真正在动手的同学。
-
----
-
 ## 🧑‍💻 项目维护者
 
 <table>
   <tr>
     <td align="center">
-      <a href="https://github.com/liboyang0730">
-        <img src="https://github.com/liboyang0730.png" width="100px;" alt="liboyang0730"/>
-        <br />
-        <sub><b>Zlatan (liboyang0730)</b></sub>
-      </a>
-      <br />
-      <sub>项目负责人</sub>
-    </td>
-    <td align="center">
       <a href="https://github.com/webup">
         <img src="https://github.com/webup.png" width="100px;" alt="webup"/>
         <br />
         <sub><b>Haili Zhang (webup)</b></sub>
+      </a>
+      <br />
+      <sub>项目维护者</sub>
+    </td>
+    <td align="center">
+      <a href="https://github.com/liboyang0730">
+        <img src="https://github.com/liboyang0730.png" width="100px;" alt="liboyang0730"/>
+        <br />
+        <sub><b>Zlatan (liboyang0730)</b></sub>
       </a>
       <br />
       <sub>项目维护者</sub>


### PR DESCRIPTION
## 改动说明

- 移除 README 中的「模型算力支持」(SiliconFlow) 章节
- 维护者统一标注为「项目维护者」，并调整 webup / liboyang0730 的展示顺序

🤖 Generated with [Claude Code](https://claude.com/claude-code)