### PR TITLE
docs: 改写友情链接文案并修正联系作者链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,9 @@ python3 d1_1_base.py
 
 ## 友情链接
 
-本课程开发者 [沧海九粟](https://space.bilibili.com/28357052) 在 DataWhale 又开源的另一门课程 —— [《Deep Agents 实战》](https://github.com/datawhalechina/deepagents-in-action)。面向想要动手构建 Agent 的开发者，系统讲解虚拟文件系统、任务规划、子 Agent、Skills、Memory 等核心能力。欢迎大家来学习和积极参与共建。
+这里为大家介绍本课程开发者 [沧海九粟](https://space.bilibili.com/28357052) 在 DataWhale 开源的另外一门进阶课程 —— [《Deep Agents 实战》](https://github.com/datawhalechina/deepagents-in-action)。
+
+这门课程，会面向想要动手构建 Agent 的开发者，系统地讲解虚拟文件系统、任务规划、子 Agent、Skills、Memory 等核心能力。欢迎大家来学习和积极参与共建。
 
 ---
 
@@ -168,7 +170,7 @@ python3 d1_1_base.py
 </table>
 
 - 🎁 **新用户福利**：通过 [课程专属注册链接](https://cloud.siliconflow.cn/i/Fq9zUwPf) 注册并完成实名认证，即可获得 **16 元全平台通用代金券**，可用于平台上百余种模型的调用，足够跑通本课程的全部示例。
-- 🧪 **实验配额补贴池**：用上面的链接注册时，作者也会获得平台返利。这部分返利会**全额回馈给学员**——汇集成一个「实验配额补贴池」：跟着课程做实验、复现示例时如果额度不够用，可以[联系作者](https://space.bilibili.com/3546900567427713)申请额外的算力配额补贴，把福利转回给真正在动手的同学。
+- 🧪 **实验配额补贴池**：用上面的链接注册时，作者也会获得平台返利。这部分返利会**全额回馈给学员**——汇集成一个「实验配额补贴池」：跟着课程做实验、复现示例时如果额度不够用，可以[联系作者](https://space.bilibili.com/28357052)申请额外的算力配额补贴，把福利转回给真正在动手的同学。
 
 ---
 


### PR DESCRIPTION
## 改动说明

- 友情链接段落改写为两段，介绍《Deep Agents 实战》进阶课程
- 修正「实验配额补贴池」中的联系作者 B 站链接为 28357052

🤖 Generated with [Claude Code](https://claude.com/claude-code)