### PR TITLE
feat: 新增扩展篇 X1 探究 AI Agent 记忆系统

### DIFF
--- a/code/X1/.env.example
+++ b/code/X1/.env.example
@@ -1,0 +1,9 @@
+# X1 实验代码环境配置
+
+# Embedding 服务 API Key（仅涉及 embedding 的实验需要）
+# OPENAI_API_KEY=sk-your-key-here
+# OPENAI_BASE_URL=https://api.openai.com/v1
+
+# PowerMem 配置（本实验代码不使用实际 PowerMem，保留作参考）
+# POWERMEM_DB_URL=sqlite:///memory.db
+# POWERMEM_SEEKDB_URL=http://localhost:8080

--- a/code/X1/README.md
+++ b/code/X1/README.md
@@ -1,0 +1,65 @@
+# X1 实验代码
+
+> 配套 [X1 探究 AI Agent 记忆系统：从遗忘曲线到永久记忆](../../docs/extra/X1%20探究%20AI%20Agent%20记忆系统：从遗忘曲线到永久记忆.md) 系列文章
+
+## 环境要求
+
+- Python 3.10+
+- 无需 PowerMem 或 SeekDB 环境
+- 所有实验使用纯 Python 标准库 + JSON fixtures，**无需 `pip install` 任何第三方包**
+
+> 说明：本目录下的脚本用主题关键词字典模拟 embedding 相似度（避免引入 jieba / numpy / openai 等依赖）。生产环境中应替换为真实的向量检索。
+
+## 配置
+
+`.env.example` 仅为后续接入真实 embedding 服务时参考，当前 15 个脚本都不会调用任何外部 API。
+
+## Windows 用户请注意中文编码
+
+Windows 默认控制台是 GBK 编码，直接运行可能导致中文输出乱码。建议在终端先执行：
+
+```bash
+set PYTHONUTF8=1
+# 或
+set PYTHONIOENCODING=utf-8
+```
+
+PowerShell 用户：
+
+```powershell
+$env:PYTHONUTF8=1
+```
+
+之后再 `python xxx.py`，中文输出即可正常显示。
+
+## 实验导航
+
+### 上篇：记忆的生命周期工程（[`part1_decay_conflict/`](part1_decay_conflict/)）
+
+| 脚本 | 说明 |
+| --- | --- |
+| `x1_1_decay_score_demo.py` | 遗忘分数计算与分层倍率演示 |
+| `x1_2_decay_param_ablation.py` | λ / 归档阈值对比实验 |
+| `x1_3_retrieval_with_decay.py` | 两阶段检索：粗筛 + 精排 |
+| `x1_4_conflict_detect.py` | 冲突检测与路由 |
+| `x1_5_conflict_resolve.py` | 双时态写入、版本失效 |
+| `x1_6_retrieval_aggregate.py` | 确定性聚合 vs LLM 判断对比 |
+
+### 中篇：记忆的边界与信任（[`part2_namespace/`](part2_namespace/)）
+
+| 脚本 | 说明 |
+| --- | --- |
+| `x1_7_namespace_isolation.py` | 命名空间隔离验证 |
+| `x1_8_promote_and_share.py` | 权限提升与共享 |
+| `x1_9_cross_agent_query.py` | 查询构建阶段过滤 |
+| `x1_10_concurrent_write.py` | 并发写入冲突 |
+
+### 下篇：从记忆到认知（[`part3_consolidation/`](part3_consolidation/)）
+
+| 脚本 | 说明 |
+| --- | --- |
+| `x1_11_consolidation_passive.py` | 高重要性直通长期层 |
+| `x1_12_consolidation_reflection.py` | Reflection 蒸馏 |
+| `x1_13_profile_vs_facts.py` | 画像 + 事实库组合检索 |
+| `x1_14_experience_distill.py` | 情景记忆 → 经验三元组 |
+| `x1_15_benchmark_runner.py` | 简易评测跑分 |

--- a/code/X1/part1_decay_conflict/README.md
+++ b/code/X1/part1_decay_conflict/README.md
@@ -1,0 +1,26 @@
+# 上篇实验：记忆的生命周期工程
+
+配套 [X1-1 记忆的生命周期工程](../../../docs/extra/X1-1%20记忆的生命周期工程.md)
+
+## 运行环境
+
+- Python 3.10+
+- 仅使用标准库（`math` / `json` / `datetime` 等），无需额外安装
+
+## 实验列表
+
+| 序号 | 脚本 | 对应正文节 | 核心观察 |
+| --- | --- | --- | --- |
+| 1 | `x1_1_decay_score_demo.py` | §1.2-1.3 | 三层记忆在不同时间跨度的保留率差异，访问强化效果 |
+| 2 | `x1_2_decay_param_ablation.py` | §2.2 | λ 对误忘率和检索质量的影响 |
+| 3 | `x1_3_retrieval_with_decay.py` | §3.1 | 两阶段检索：粗筛 + 精排，访问强化对检索排序的改变 |
+| 4 | `x1_4_conflict_detect.py` | §4.1 | 主题相似度初筛 + 规则路由（ADD/UPDATE/DELETE） |
+| 5 | `x1_5_conflict_resolve.py` | §4.2 | is_active 标记切换、版本链追溯 |
+| 6 | `x1_6_retrieval_aggregate.py` | §4.3 | 确定性聚合与全量返回对比 |
+
+## 数据说明
+
+`fixtures/sample_memories.json` 包含：
+- 12 条不同层级、不同时间的模拟记忆（覆盖 working / short_term / long_term）
+- 5 个冲突测试用例（矛盾、并存、细化、时间演进）
+- 4 个检索查询及预期答案

--- a/code/X1/part1_decay_conflict/fixtures/sample_memories.json
+++ b/code/X1/part1_decay_conflict/fixtures/sample_memories.json
@@ -1,0 +1,192 @@
+{
+  "memories": [
+    {
+      "id": "mem_001",
+      "content": "用户是 Python 后端开发者，有 5 年经验",
+      "importance_score": 0.85,
+      "memory_type": "long_term",
+      "created_at": "2025-12-01T10:00:00",
+      "last_reviewed": "2025-12-15T10:00:00",
+      "access_count": 12,
+      "is_active": true
+    },
+    {
+      "id": "mem_002",
+      "content": "用户偏好简洁的代码风格，不喜欢过多的注释",
+      "importance_score": 0.65,
+      "memory_type": "short_term",
+      "created_at": "2025-12-10T14:30:00",
+      "last_reviewed": "2025-12-20T14:30:00",
+      "access_count": 5,
+      "is_active": true
+    },
+    {
+      "id": "mem_003",
+      "content": "用户最近在学习 Rust 语言，是初学者",
+      "importance_score": 0.70,
+      "memory_type": "short_term",
+      "created_at": "2026-01-05T09:00:00",
+      "last_reviewed": "2026-01-05T09:00:00",
+      "access_count": 2,
+      "is_active": true
+    },
+    {
+      "id": "mem_004",
+      "content": "用户对花生过敏，所有食物相关建议必须避开花生",
+      "importance_score": 0.95,
+      "memory_type": "long_term",
+      "created_at": "2025-06-01T08:00:00",
+      "last_reviewed": "2025-10-01T08:00:00",
+      "access_count": 1,
+      "is_active": true
+    },
+    {
+      "id": "mem_005",
+      "content": "用户喜欢用 VS Code 编辑器",
+      "importance_score": 0.40,
+      "memory_type": "working",
+      "created_at": "2026-01-10T16:00:00",
+      "last_reviewed": "2026-01-10T16:00:00",
+      "access_count": 1,
+      "is_active": true
+    },
+    {
+      "id": "mem_006",
+      "content": "用户正在做一个电商项目，技术栈是 Django + PostgreSQL",
+      "importance_score": 0.75,
+      "memory_type": "short_term",
+      "created_at": "2026-01-08T11:00:00",
+      "last_reviewed": "2026-01-12T11:00:00",
+      "access_count": 3,
+      "is_active": true
+    },
+    {
+      "id": "mem_007",
+      "content": "用户最喜欢吃披萨，尤其是意式薄底披萨",
+      "importance_score": 0.35,
+      "memory_type": "working",
+      "created_at": "2025-11-15T19:00:00",
+      "last_reviewed": "2025-11-15T19:00:00",
+      "access_count": 0,
+      "is_active": true
+    },
+    {
+      "id": "mem_008",
+      "content": "用户最近三周在吃素",
+      "importance_score": 0.50,
+      "memory_type": "working",
+      "created_at": "2026-01-01T12:00:00",
+      "last_reviewed": "2026-01-01T12:00:00",
+      "access_count": 1,
+      "is_active": true
+    },
+    {
+      "id": "mem_009",
+      "content": "用户目前主要使用 Java 开发后端服务",
+      "importance_score": 0.80,
+      "memory_type": "long_term",
+      "created_at": "2025-08-01T10:00:00",
+      "last_reviewed": "2025-12-01T10:00:00",
+      "access_count": 8,
+      "is_active": false
+    },
+    {
+      "id": "mem_010",
+      "content": "用户已从 Java 全面转向 Go 语言开发",
+      "importance_score": 0.82,
+      "memory_type": "long_term",
+      "created_at": "2026-01-02T10:00:00",
+      "last_reviewed": "2026-01-02T10:00:00",
+      "access_count": 3,
+      "is_active": true
+    },
+    {
+      "id": "mem_011",
+      "content": "用户公司使用 AWS 作为云平台",
+      "importance_score": 0.72,
+      "memory_type": "short_term",
+      "created_at": "2025-10-01T09:00:00",
+      "last_reviewed": "2025-12-15T09:00:00",
+      "access_count": 4,
+      "is_active": false
+    },
+    {
+      "id": "mem_012",
+      "content": "用户公司已从 AWS 迁移到阿里云",
+      "importance_score": 0.74,
+      "memory_type": "short_term",
+      "created_at": "2026-01-08T09:00:00",
+      "last_reviewed": "2026-01-08T09:00:00",
+      "access_count": 2,
+      "is_active": true
+    }
+  ],
+  "conflict_cases": [
+    {
+      "id": "case_001",
+      "description": "直接矛盾：技术栈变更",
+      "old_memory": "用户主要使用 Java 开发后端服务",
+      "new_fact": "用户已全面转向 Go 语言，不再使用 Java",
+      "expected_action": "UPDATE",
+      "expected_reason": "新事实直接替代旧事实，旧版标记 is_active=False"
+    },
+    {
+      "id": "case_002",
+      "description": "并存偏好：食物偏好不矛盾",
+      "old_memory": "用户最喜欢吃披萨，尤其是意式薄底披萨",
+      "new_fact": "用户最近三周在吃素",
+      "expected_action": "ADD",
+      "expected_reason": "两条偏好并存，不构成矛盾，各自独立衰减"
+    },
+    {
+      "id": "case_003",
+      "description": "时间演进：云平台迁移",
+      "old_memory": "用户公司使用 AWS 作为云平台",
+      "new_fact": "用户公司已从 AWS 迁移到阿里云",
+      "expected_action": "UPDATE",
+      "expected_reason": "事实随时间演进，旧版失效、新版 active"
+    },
+    {
+      "id": "case_004",
+      "description": "直接矛盾：饮食偏好",
+      "old_memory": "用户最喜欢吃披萨，尤其是意式薄底披萨",
+      "new_fact": "用户非常讨厌披萨，从来不吃",
+      "expected_action": "DELETE",
+      "expected_reason": "直接矛盾，删除旧偏好"
+    },
+    {
+      "id": "case_005",
+      "description": "细化补充：同一话题更多细节",
+      "old_memory": "用户正在做一个电商项目",
+      "new_fact": "用户的电商项目用 Django + PostgreSQL，涉及跨境支付",
+      "expected_action": "UPDATE",
+      "expected_reason": "新事实是旧事实的细化，应合并更新"
+    }
+  ],
+  "queries": [
+    {
+      "id": "q_001",
+      "query_text": "用户用什么编程语言？",
+      "expected_answer_deterministic": "用户已从 Java 全面转向 Go 语言开发",
+      "note": "确定性聚合应返回最新 active 版本（Go），而非旧版（Java）"
+    },
+    {
+      "id": "q_002",
+      "query_text": "用户喜欢吃什么？",
+      "expected_answer_context": "用户最喜欢吃披萨，但最近在吃素",
+      "note": "需要同时返回两条并存偏好，留给 LLM 综合判断"
+    },
+    {
+      "id": "q_003",
+      "query_text": "用户的云服务用哪家？",
+      "expected_answer_deterministic": "用户公司已从 AWS 迁移到阿里云",
+      "note": "迁移类场景，新版 active 为准"
+    },
+    {
+      "id": "q_004",
+      "query_text": "推荐一个适合用户的后端框架",
+      "expected_context": "用户是 Python 开发者（mem_001），正在学 Rust（mem_003），但主力是 Go（mem_010）",
+      "note": "多记忆综合，多种技术栈并存"
+    }
+  ]
+}

--- a/code/X1/part1_decay_conflict/x1_1_decay_score_demo.py
+++ b/code/X1/part1_decay_conflict/x1_1_decay_score_demo.py
@@ -1,0 +1,192 @@
+"""
+x1_1_decay_score_demo.py — 遗忘分数计算与分层倍率演示
+
+本脚本直观展示 PowerMem 艾宾浩斯遗忘公式的计算过程:
+  R = e^(-t / (24 * S))
+
+其中强度 S = decay_rate × 层级倍率 × (1 + log(1 + access_count))
+
+运行:
+  python x1_1_decay_score_demo.py
+
+输出观察点:
+  - working/short_term/long_term 三层记忆在 1h/1d/7d/30d/90d 后的保留率差异
+  - 长期层 vs 临时层在同时间下的保留率差距可达数倍
+  - 访问强化: 同一条记忆被检索次数越多，衰减越慢
+
+对应正文: X1-1 §1.2-1.3 "从经典公式到工程形式 / 强度 S 的三个因子"
+"""
+
+import math
+from datetime import datetime, timedelta
+
+
+# ============================================================
+# PowerMem 核心参数（来源: ebbinghaus_algorithm.py）
+# ============================================================
+
+# λ (decay_rate): 全局衰减速率常数
+# 值越大 → 所有记忆衰减越慢。PowerMem 默认 1.5，可通过配置文件覆盖
+DEFAULT_DECAY_RATE = 1.5
+
+# 层级倍率: 决定三层记忆的衰减速度差距
+# working(临时层) 的强度是 1.5 × 1 = 1.5
+# short_term(中期层) 的强度是 1.5 × 7 = 10.5
+# long_term(长期层) 的强度是 1.5 × 60 = 90
+# 长期层有效强度是临时层的 60 倍——这就是"永久记忆"和"临时笔记"的本质差距
+DEFAULT_DECAY_RATE_MULTIPLIERS = {
+    "working": 1,       # 临时层: 当前任务相关，衰减最快，几小时内就明显下降
+    "short_term": 7,    # 中期层: 近期交互记忆，可维持数周到数月
+    "long_term": 60,    # 长期层: 稳定事实和偏好，衰减极慢，接近"永久"
+}
+
+# 复习时的强化比例
+# 每次回顾这条记忆后，保留率恢复: new = old + 0.3 × (1 - old)
+DEFAULT_REINFORCEMENT_FACTOR = 0.3
+
+# 模拟衰减计算的参考时间点（相当于"现在"）
+NOW = datetime(2026, 2, 1, 12, 0, 0)
+
+
+def calculate_strength(memory_type: str, access_count: int,
+                       decay_rate: float = DEFAULT_DECAY_RATE) -> float:
+    """
+    计算记忆的「有效强度」S。
+
+    S 是艾宾浩斯公式 R = e^(-t / (24*S)) 中控制衰减速度的核心参数。
+    S 越大 → 分母 24*S 越大 → e^(-t/大数) 衰减越慢。
+
+    参数:
+      memory_type: "working" / "short_term" / "long_term"
+                   决定从 DEFAULT_DECAY_RATE_MULTIPLIERS 中取哪个倍率
+      access_count: 这条记忆历史上被检索命中的次数
+                    log1p 将其转换为递增但收益递减的强化因子
+      decay_rate:   全局 λ，默认 1.5
+
+    返回:
+      S = decay_rate × 层级倍率 × (1 + log(1 + access_count))
+      - working:  S ≈ 1.5   (access_count=0 时)
+      - long_term: S ≈ 90    (access_count=0 时)
+    """
+    multiplier = DEFAULT_DECAY_RATE_MULTIPLIERS[memory_type]
+    reinforcement = math.log1p(access_count)
+    return decay_rate * multiplier * (1 + reinforcement)
+
+
+def calculate_retention(
+    created_at: datetime,
+    memory_type: str,
+    access_count: int,
+    current_time: datetime = NOW,
+    decay_rate: float = DEFAULT_DECAY_RATE,
+) -> float:
+    """
+    计算记忆在当前时刻的保留率 R ∈ [0.0, 1.0]。
+
+    1.0 = 完全没衰减；< 0.3 = 视为"遗忘"。
+    """
+    hours_elapsed = (current_time - created_at).total_seconds() / 3600
+    strength = calculate_strength(memory_type, access_count, decay_rate)
+    retention = math.exp(-hours_elapsed / (24 * strength))
+    return max(0.0, min(1.0, retention))
+
+
+def _format_bar(value: float, width: int = 30) -> str:
+    """把 [0,1] 数值转成 #.... 进度条"""
+    filled = int(value * width)
+    return "#" * filled + "." * (width - filled)
+
+
+def main():
+    print("=" * 90)
+    print("X1-1 遗忘分数计算与分层倍率演示")
+    print(f"全局 λ (decay_rate) = {DEFAULT_DECAY_RATE}")
+    print(f"层级倍率 = {DEFAULT_DECAY_RATE_MULTIPLIERS}")
+    print(f"模拟时间起点 NOW = {NOW.strftime('%Y-%m-%d %H:%M')}")
+    print("=" * 90)
+
+    # ============================================================
+    # 第一部分：三层记忆在同一时间轴上的保留率对比
+    # ============================================================
+    print(f"\n{'─' * 90}")
+    print("第一部分：三层记忆在同一时间轴上的保留率（access_count = 0）")
+    print(f"{'─' * 90}")
+
+    time_points = [
+        ("1 小时", timedelta(hours=1)),
+        ("1 天", timedelta(days=1)),
+        ("7 天", timedelta(days=7)),
+        ("30 天", timedelta(days=30)),
+        ("90 天", timedelta(days=90)),
+    ]
+
+    print(f"\n  {'时间跨度':<10}", end="")
+    for layer in ("working", "short_term", "long_term"):
+        print(f"  {layer:<22}", end="")
+    print()
+    print(f"  {'-' * 80}")
+
+    for label, delta in time_points:
+        created = NOW - delta
+        print(f"  {label:<10}", end="")
+        for layer in ("working", "short_term", "long_term"):
+            r = calculate_retention(created, layer, access_count=0)
+            print(f"  {r:.4f} {_format_bar(r, 18)}", end="")
+        print()
+
+    r_work_30d = calculate_retention(NOW - timedelta(days=30), "working", 0)
+    r_long_30d = calculate_retention(NOW - timedelta(days=30), "long_term", 0)
+    r_work_90d = calculate_retention(NOW - timedelta(days=90), "working", 0)
+    r_long_90d = calculate_retention(NOW - timedelta(days=90), "long_term", 0)
+    print(f"\n  关键差距：")
+    if r_work_30d > 1e-6:
+        print(f"    - 30 天后临时层 R = {r_work_30d:.4f}，长期层 R = {r_long_30d:.4f}，"
+              f"差距约 {r_long_30d / r_work_30d:.0f} 倍")
+    else:
+        print(f"    - 30 天后临时层 R ≈ 0（已遗忘），长期层 R = {r_long_30d:.4f}——"
+              f"两者已不在同一数量级")
+    print(f"    - 90 天后临时层 R = {r_work_90d:.4f}（已遗忘），"
+          f"长期层 R = {r_long_90d:.4f}（仍可召回）")
+
+    # ============================================================
+    # 第二部分：访问强化效果——同一记忆被多次检索后曲线被"拉平"
+    # ============================================================
+    print(f"\n{'─' * 90}")
+    print("第二部分：访问强化对长期层记忆的影响")
+    print("  场景: 同一条 long_term 记忆，access_count 从 0 → 50，30 天后的保留率")
+    print(f"{'─' * 90}")
+
+    print(f"\n  {'访问次数':<10} {'强度 S':<12} {'30 天后 R':<12} {'曲线':<32}")
+    print(f"  {'-' * 70}")
+    for n in (0, 1, 3, 5, 10, 20, 50):
+        s = calculate_strength("long_term", n)
+        r = calculate_retention(NOW - timedelta(days=30), "long_term", n)
+        print(f"  {n:<10} {s:<12.2f} {r:<12.4f} {_format_bar(r, 30)}")
+
+    print(f"\n  观察：")
+    print(f"    - access_count=0 时 S=90；access_count=50 时 S≈90×(1+log(51))≈444")
+    print(f"    - 访问次数翻倍并不能让 S 翻倍——log1p 是收益递减的强化因子")
+    print(f"    - 让一条记忆衰减更慢的最有效办法仍是把它写进更高层级，而非反复检索。")
+
+    # ============================================================
+    # 第三部分：层级选错，后果有多严重
+    # ============================================================
+    print(f"\n{'─' * 90}")
+    print("第三部分：层级选错的代价——同一事实写入不同层级的 30 天命运")
+    print(f"{'─' * 90}")
+    fact = "用户对花生过敏"
+    print(f"\n  假设事实「{fact}」被写入不同层级，30 天后的保留率：")
+    for layer in ("working", "short_term", "long_term"):
+        s = calculate_strength(layer, 0)
+        r = calculate_retention(NOW - timedelta(days=30), layer, 0)
+        bar = _format_bar(r, 30)
+        verdict = "✓ 仍可召回" if r >= 0.3 else "✗ 已被遗忘"
+        print(f"    {layer:<12} S={s:<7.1f} R={r:.4f} {bar}  {verdict}")
+
+    print(f"\n  写入瞬间选错层级 = 决定了这条记忆能「活」多久。")
+    print(f"  层级倍率 60 不是抽象参数，而是「长期事实」和「临时闲聊」之间数量级的差距。")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/code/X1/part1_decay_conflict/x1_2_decay_param_ablation.py
+++ b/code/X1/part1_decay_conflict/x1_2_decay_param_ablation.py
@@ -1,0 +1,190 @@
+"""
+x1_2_decay_param_ablation.py — λ / 归档阈值消融实验
+
+本脚本回答一个问题: decay_rate (λ) 该设为多少？
+
+方法: 在同一批记忆上，依次用 λ = 0.5 / 1.0 / 1.5 / 3.0 / 5.0 跑衰减计算，
+      对比每种 λ 下「保留率分布」和「误忘率」(高重要性记忆被错误淘汰的比例)。
+
+运行:
+  python x1_2_decay_param_ablation.py
+
+输入: fixtures/sample_memories.json (12 条不同层级和重要性的模拟记忆)
+输出:
+  - 每种 λ 下的保留记忆数 vs 遗忘记忆数
+  - 误忘计数 (importance_score ≥ 0.8 但 retention < 0.3 的记忆)
+  - 逐条记忆在不同 λ 下的保留率详情
+  - 推荐 λ 值
+
+关键参数:
+  archive_threshold = 0.3: 保留率低于此值视为"遗忘"
+  λ 的选择需要在"噪声控制"和"误忘防止"之间取得平衡:
+  - λ < 1.0: 保守，几乎不遗忘，检索质量下降
+  - λ = 1.5: PowerMem 默认值，平衡点
+  - λ > 3.0: 激进，快速淘汰，可能误忘重要信息
+
+对应正文: X1-1 §2.2 "λ 怎么选：用同一批数据做对比"
+"""
+
+import math
+import json
+import os
+from datetime import datetime, timedelta
+
+
+DEFAULT_DECAY_RATE_MULTIPLIERS = {
+    "working": 1,
+    "short_term": 7,
+    "long_term": 60,
+}
+NOW = datetime(2026, 2, 1, 12, 0, 0)
+
+
+def calculate_retention(
+    created_at: datetime,
+    memory_type: str,     # "working" / "short_term" / "long_term", 决定衰减倍率
+    access_count: int,    # 历史访问次数, 用于 log1p 强化因子
+    decay_rate: float,    # 此次消融实验的 λ 值
+) -> float:
+    """
+    使用指定的 λ 值计算保留率 R = e^(-t / (24*S))。
+    与 x1_1 中的同名函数逻辑一致, 但 decay_rate 是参数而非全局常量。
+    """
+    # t: 从创建到当前(2026-02-01)的小时数
+    hours_elapsed = (NOW - created_at).total_seconds() / 3600
+
+    # 层级倍率: working=1, short_term=7, long_term=60
+    multiplier = DEFAULT_DECAY_RATE_MULTIPLIERS.get(memory_type, 1)
+
+    # 访问强化: log(1 + access_count), 访问越多衰减越慢
+    reinforcement = math.log1p(access_count)
+
+    # S = λ × 层级倍率 × (1 + 访问强化)
+    strength = decay_rate * multiplier * (1 + reinforcement)
+
+    # R = e^(-t / (24*S)), clamp 到 [0, 1]
+    return max(0.0, min(1.0, math.exp(-hours_elapsed / (24 * strength))))
+
+
+def load_memories(filepath: str) -> list:
+    with open(filepath, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return data["memories"]
+
+
+def run_ablation(memories: list, lambdas: list[float], archive_threshold: float = 0.3):
+    """运行消融实验"""
+    results = []
+    for lam in lambdas:
+        retained = 0
+        forgotten = 0
+        forgotten_important = 0  # 误忘计数（重要性 ≥ 0.8 但保留率 < 阈值）
+        total_importance_high = 0
+
+        for mem in memories:
+            ct = datetime.fromisoformat(mem["created_at"])
+            r = calculate_retention(ct, mem["memory_type"], mem["access_count"], lam)
+
+            if r >= archive_threshold:
+                retained += 1
+            else:
+                forgotten += 1
+                if mem["importance_score"] >= 0.8:
+                    forgotten_important += 1
+
+            if mem["importance_score"] >= 0.8:
+                total_importance_high += 1
+
+        total = len(memories)
+        miss_rate = forgotten_important / total_importance_high if total_importance_high > 0 else 0
+
+        results.append({
+            "lambda": lam,
+            "retained": retained,
+            "forgotten": forgotten,
+            "retention_ratio": retained / total,
+            "forgotten_important": forgotten_important,
+            "total_important": total_importance_high,
+            "miss_rate": miss_rate,
+        })
+    return results
+
+
+def main():
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    fixtures_path = os.path.join(script_dir, "fixtures", "sample_memories.json")
+
+    memories = load_memories(fixtures_path)
+
+    lambdas = [0.5, 1.0, 1.5, 2.0, 3.0, 5.0]
+    archive_threshold = 0.3
+
+    print("=" * 85)
+    print("X1-2 λ 消融实验")
+    print(f"模拟时间: {NOW.strftime('%Y-%m-%d')}")
+    print(f"归档阈值: {archive_threshold}（保留率低于此值视为遗忘）")
+    print(f"记忆总数: {len(memories)}")
+    print("=" * 85)
+
+    results = run_ablation(memories, lambdas, archive_threshold)
+
+    print(f"\n{'λ':<8} {'保留':<6} {'遗忘':<6} {'保留率':<10} {'误忘高价值':<12} {'误忘率':<10}")
+    print("-" * 85)
+    for r in results:
+        print(f"  {r['lambda']:<8} {r['retained']:<6} {r['forgotten']:<6} "
+              f"{r['retention_ratio']:.2%}       {r['forgotten_important']}/{r['total_important']:<8}     {r['miss_rate']:.2%}")
+
+    # 详细展开：每条记忆在不同 λ 下的保留率
+    print(f"\n{'=' * 85}")
+    print("逐条记忆保留率详情")
+    print(f"{'=' * 85}")
+
+    for mem in memories:
+        ct = datetime.fromisoformat(mem["created_at"])
+        print(f"\n  [{mem['id']}] {mem['content'][:60]}...")
+        print(f"    类型={mem['memory_type']}, 重要性={mem['importance_score']}, "
+              f"访问次数={mem['access_count']}, 距今={(NOW - ct).days} 天")
+        print(f"    {'λ=0.5':<10} {'λ=1.0':<10} {'λ=1.5':<10} {'λ=2.0':<10} {'λ=3.0':<10} {'λ=5.0':<10}")
+        retain_vals = []
+        for lam in lambdas:
+            r = calculate_retention(ct, mem["memory_type"], mem["access_count"], lam)
+            retain_vals.append(f"{r:.4f}")
+        print(f"    {'  '.join(retain_vals)}")
+
+    # 重点标注误忘案例
+    print(f"\n{'=' * 85}")
+    print("误忘风险分析（归档阈值 = 0.3）")
+    print(f"{'=' * 85}")
+    for lam in lambdas:
+        risky = []
+        for mem in memories:
+            ct = datetime.fromisoformat(mem["created_at"])
+            r = calculate_retention(ct, mem["memory_type"], mem["access_count"], lam)
+            if mem["importance_score"] >= 0.8 and r < archive_threshold:
+                risky.append((mem["id"], mem["content"][:50], r))
+        if risky:
+            print(f"\n  λ={lam} 时，以下高价值记忆会被误忘：")
+            for mid, content, r in risky:
+                print(f"    [!] {mid}: {content}... (保留率={r:.4f})")
+        else:
+            print(f"\n  λ={lam}: 无高价值记忆被误忘")
+
+    # 推荐结论
+    print(f"\n{'=' * 85}")
+    print("分析结论")
+    print(f"{'=' * 85}")
+    best = min(results, key=lambda x: abs(x["retention_ratio"] - 0.75))
+    first_zero_miss = next((r["lambda"] for r in results if r["miss_rate"] == 0), None)
+    print(f"  若目标保留率约 75%，推荐 λ ≈ {best['lambda']}")
+    if first_zero_miss is not None:
+        # 公式：λ 越大 → S 越大 → 衰减越慢 → 误忘越少
+        # 所以「零误忘」应取 λ ≥ first_zero_miss
+        print(f"  若对数据安全要求高（零误忘），建议 λ ≥ {first_zero_miss}")
+    else:
+        print(f"  当前 λ 区间内仍有误忘，建议进一步增大 λ 或下调归档阈值")
+    print(f"  注意：λ 的选择还需结合检索准确率综合评估（见 x1_3）")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/code/X1/part1_decay_conflict/x1_3_retrieval_with_decay.py
+++ b/code/X1/part1_decay_conflict/x1_3_retrieval_with_decay.py
@@ -1,0 +1,200 @@
+"""
+x1_3_retrieval_with_decay.py — 两阶段检索：粗筛 + 精排
+
+本脚本演示衰减如何融入检索流程。核心公式:
+  final_score = semantic_score × retention × forgotten_multiplier
+
+运行:
+  python x1_3_retrieval_with_decay.py
+
+输入: fixtures/sample_memories.json
+输出:
+  - 同一 query 下「仅语义排序」与「语义×衰减排序」的 Top-5 结果对比
+  - 哪些记忆因访问强化进入 Top-N，哪些因衰减被挤出 Top-N
+  - 被遗忘记忆的降权效果
+
+关键设计决策: 不是简单的"相似度 × 衰减"一步到位，而是:
+  阶段 1 (粗筛): 向量索引快速过滤 → 圈定候选集 (几十到几百条)
+  阶段 2 (精排): 只在候选集上叠加衰减维度 → final_score 排序
+  这样做的原因是百万级记忆无法逐条算衰减分再排——粗筛用向量索引的毫秒级性能。
+
+对应正文: X1-1 §3.1 "两阶段检索：先语义，再衰减"
+"""
+
+import math
+import json
+import os
+from datetime import datetime
+
+
+NOW = datetime(2026, 2, 1, 12, 0, 0)
+DEFAULT_DECAY_RATE = 1.5
+DEFAULT_DECAY_RATE_MULTIPLIERS = {"working": 1, "short_term": 7, "long_term": 60}
+FORGOTTEN_SCORE_MULTIPLIER = 0.1
+ARCHIVE_THRESHOLD = 0.3
+
+
+def calculate_retention(created_at: datetime, memory_type: str, access_count: int) -> float:
+    hours_elapsed = (NOW - created_at).total_seconds() / 3600
+    multiplier = DEFAULT_DECAY_RATE_MULTIPLIERS.get(memory_type, 1)
+    reinforcement = math.log1p(access_count)
+    strength = DEFAULT_DECAY_RATE * multiplier * (1 + reinforcement)
+    return max(0.0, min(1.0, math.exp(-hours_elapsed / (24 * strength))))
+
+
+def load_memories(filepath: str) -> list:
+    with open(filepath, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return data["memories"]
+
+
+def simulate_semantic_score(memory: dict, query: str) -> float:
+    """
+    模拟语义相似度分数（中文友好）。
+    实际系统中这是 embedding 余弦相似度，这里用主题关键词字典模拟。
+
+    思路：每个语义主题（编程语言、食物偏好、云平台等）维护一组关键词；
+    - 先识别 query 涉及哪些主题；
+    - 然后看 memory 的内容在该主题下命中了多少关键词。
+    这样既贴近"语义相关"的直觉，又不需要真正的 embedding 模型。
+    """
+    content = memory["content"]
+
+    # 主题词典：覆盖示例库 12 条记忆的所有话题
+    topic_keywords = {
+        "编程语言": ["Python", "Java", "Go", "Rust", "编程", "语言", "开发", "后端", "主力", "微服务", "框架"],
+        "食物偏好": ["吃", "披萨", "素", "食物", "饮食", "餐厅", "过敏", "花生", "肉类"],
+        "云平台": ["AWS", "阿里云", "云", "平台", "迁移", "公司"],
+        "编辑器": ["VS Code", "编辑器", "IDE", "插件"],
+        "电商项目": ["电商", "项目", "Django", "PostgreSQL", "技术栈"],
+        "代码风格": ["代码", "风格", "注释", "简洁"],
+        "学习": ["学", "教程", "初学者", "考虑"],
+    }
+
+    # 找出 query 涉及的主题
+    query_topics = [
+        topic for topic, keywords in topic_keywords.items()
+        if any(kw in query for kw in keywords)
+    ]
+
+    if not query_topics:
+        # 兜底：query 没识别出主题，返回最低分（仍高于粗筛阈值以保证可见性）
+        return 0.10
+
+    # 在相关主题下，统计 memory 命中的关键词数
+    score = 0.0
+    for topic in query_topics:
+        keywords = topic_keywords[topic]
+        hits = sum(1 for kw in keywords if kw in content)
+        score += hits * 0.20
+
+    return min(1.0, score)
+
+
+def two_stage_retrieval(
+    memories: list,
+    query: str,
+    quality_threshold: float = 0.15,
+    use_decay: bool = True,
+) -> list:
+    """
+    两阶段检索：
+    1. 粗筛：过滤 semantic_score < quality_threshold 的记忆
+    2. 精排：semantic_score × retention（如果 use_decay=True）
+    """
+    candidates = []
+    for mem in memories:
+        sem_score = simulate_semantic_score(mem, query)
+        if sem_score < quality_threshold:
+            continue
+
+        retention = calculate_retention(
+            datetime.fromisoformat(mem["created_at"]),
+            mem["memory_type"],
+            mem["access_count"],
+        )
+
+        is_forgotten = retention < ARCHIVE_THRESHOLD
+        forgotten_mult = FORGOTTEN_SCORE_MULTIPLIER if is_forgotten else 1.0
+
+        if use_decay:
+            final_score = sem_score * retention * forgotten_mult
+        else:
+            final_score = sem_score
+
+        candidates.append({
+            "id": mem["id"],
+            "content": mem["content"],
+            "semantic_score": sem_score,
+            "retention": retention,
+            "is_forgotten": is_forgotten,
+            "final_score": final_score,
+            "memory_type": mem["memory_type"],
+            "is_active": mem["is_active"],
+        })
+
+    candidates.sort(key=lambda x: x["final_score"], reverse=True)
+    return candidates
+
+
+def main():
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    fixtures_path = os.path.join(script_dir, "fixtures", "sample_memories.json")
+    memories = load_memories(fixtures_path)
+
+    queries = [
+        "用户用什么编程语言",
+        "用户喜欢吃什么",
+        "用户用什么云平台",
+    ]
+
+    print("=" * 85)
+    print("X1-3 两阶段检索对比：仅语义排序 vs 语义×衰减排序")
+    print(f"{'=' * 85}")
+
+    for query in queries:
+        print(f"\n{'-' * 85}")
+        print(f"查询: 「{query}」")
+        print(f"{'-' * 85}")
+
+        semantic_only = two_stage_retrieval(memories, query, use_decay=False)
+        with_decay = two_stage_retrieval(memories, query, use_decay=True)
+
+        print(f"\n  {'排名':<6} {'仅语义排序':<55} {'分数':<8}")
+        print(f"  {'-' * 69}")
+        for i, c in enumerate(semantic_only[:5]):
+            print(f"  #{i+1:<5} {c['content']:<55} {c['final_score']:.3f}")
+
+        print(f"\n  {'排名':<6} {'语义×衰减排序':<50} {'分数':<8} {'保留率':<10}")
+        print(f"  {'-' * 74}")
+        for i, c in enumerate(with_decay[:5]):
+            flag = " [!]遗忘" if c["is_forgotten"] else ""
+            print(f"  #{i+1:<5} {c['content']:<47}{flag:<4}  {c['final_score']:.3f}     {c['retention']:.3f}")
+
+        # 对比变化
+        top5_sem = set(c["id"] for c in semantic_only[:5])
+        top5_decay = set(c["id"] for c in with_decay[:5])
+        promoted = top5_decay - top5_sem
+        demoted = top5_sem - top5_decay
+
+        if promoted or demoted:
+            print(f"\n  排序变化：")
+            for pid in promoted:
+                mem = next(c for c in with_decay if c["id"] == pid)
+                print(f"    ^ {pid} 进入 Top5（保留率={mem['retention']:.3f}，访问强化效果）")
+            for pid in demoted:
+                mem = next(c for c in semantic_only if c["id"] == pid)
+                print(f"    v {pid} 跌出 Top5（保留率低，衰减降权）")
+
+    # 遗忘记忆的特殊处理
+    print(f"\n{'=' * 85}")
+    print("遗忘记忆的降权效果")
+    print(f"{'=' * 85}")
+    print(f"  被标记为遗忘的记忆（保留率 < {ARCHIVE_THRESHOLD}），")
+    print(f"  final_score 会乘以 forgotten_score_multiplier = {FORGOTTEN_SCORE_MULTIPLIER}")
+    print(f"  这些记忆不会被删除，但检索排名大幅下降。")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/code/X1/part1_decay_conflict/x1_4_conflict_detect.py
+++ b/code/X1/part1_decay_conflict/x1_4_conflict_detect.py
@@ -1,0 +1,216 @@
+"""
+x1_4_conflict_detect.py — 冲突检测与路由 (ADD/UPDATE/DELETE/NONE)
+
+本脚本回答: 新事实写入时，怎么自动发现它和已有记忆是矛盾还是补充？
+
+两步流程:
+  1. 向量相似度粗筛: 新事实 embedding × 存量记忆 embedding → 余弦相似度 > threshold
+  2. 规则路由: 根据相似度高低 + 关键词特征，决定四个动作之一
+
+运行:
+  python x1_4_conflict_detect.py
+
+输出:
+  - 每条新事实 vs 存量记忆的相似度排名
+  - 路由决策 (ADD/UPDATE/DELETE/NONE) 及原因
+  - 阈值取舍分析（太高漏检 / 太低误报）
+
+关键参数:
+  similarity_threshold = 0.3: 进入候选集的最低相似度；0.25~0.35 推荐起步
+  实际系统中步骤 2 由 LLM 完成 (PowerMem 的 _decide_memory_actions)，规则版仅演示逻辑
+
+对应正文: X1-1 §4.1 "从相似度到路由决策"
+"""
+
+import json
+import os
+from typing import Literal
+
+ActionType = Literal["ADD", "UPDATE", "DELETE", "NONE"]
+
+
+def simulate_similarity(text_a: str, text_b: str) -> float:
+    """
+    模拟 embedding 余弦相似度（中文友好）。
+    实际系统中使用 embedding 模型计算，这里用「主题关键词重叠 + 字符级 Jaccard」模拟。
+    """
+    if not text_a or not text_b:
+        return 0.0
+
+    # 主题词典：覆盖示例库涉及的话题
+    topic_keywords = {
+        "编程语言": ["Python", "Java", "Go", "Rust", "编程", "语言", "开发", "后端", "主力", "框架", "微服务"],
+        "食物偏好": ["吃", "披萨", "素", "食物", "饮食", "餐厅", "过敏", "花生", "肉类"],
+        "云平台": ["AWS", "阿里云", "云平台", "云服务", "云", "迁移"],
+        "编辑器": ["VS Code", "编辑器", "IDE", "插件"],
+        "电商项目": ["电商", "项目", "Django", "PostgreSQL", "技术栈", "跨境", "支付"],
+        "代码风格": ["代码", "风格", "注释", "简洁"],
+        "学习": ["学", "教程", "初学者", "考虑", "学习"],
+    }
+
+    # 找出两条文本各自涉及的话题
+    topics_a = {t for t, kws in topic_keywords.items() if any(kw in text_a for kw in kws)}
+    topics_b = {t for t, kws in topic_keywords.items() if any(kw in text_b for kw in kws)}
+
+    # 字符级 Jaccard 作为基础分（保证同语言文本之间有非零相似度）
+    chars_a = set(text_a)
+    chars_b = set(text_b)
+    char_jaccard = len(chars_a & chars_b) / max(len(chars_a | chars_b), 1)
+
+    if not topics_a or not topics_b:
+        # 无主题识别，只用字符级
+        return min(1.0, char_jaccard * 1.5)
+
+    # 话题重叠度
+    topic_overlap = len(topics_a & topics_b) / max(len(topics_a | topics_b), 1)
+
+    # 在重叠话题下，统计共享的关键词数
+    keyword_overlap = 0
+    for topic in topics_a & topics_b:
+        kw_a = {kw for kw in topic_keywords[topic] if kw in text_a}
+        kw_b = {kw for kw in topic_keywords[topic] if kw in text_b}
+        keyword_overlap += len(kw_a & kw_b)
+
+    # 综合：话题重叠为主，关键词共享做加分，字符级做兜底
+    score = topic_overlap * 0.6 + keyword_overlap * 0.15 + char_jaccard * 0.15
+    return min(1.0, score)
+
+
+def detect_conflict(new_fact: str, existing_memories: list, similarity_threshold: float = 0.3) -> dict:
+    """
+    冲突检测主流程：
+    1. 向量相似度粗筛，取 ≥ threshold 的候选
+    2. 规则路由：判断动作类型
+    """
+    candidates = []
+    for mem in existing_memories:
+        sim = simulate_similarity(new_fact, mem["content"])
+        if sim >= similarity_threshold and mem["is_active"]:
+            candidates.append({**mem, "similarity": sim})
+
+    candidates.sort(key=lambda x: x["similarity"], reverse=True)
+
+    if not candidates:
+        return {"action": "ADD", "reason": "无相似已有记忆，新增", "candidates": []}
+
+    top = candidates[0]
+
+    # 规则路由（简化版；实际系统中由 LLM 判断）
+    # 1. 高度相似 + 关键词重叠很高 → 可能是冲突/更新
+    # 2. 中等相似 → 可能是补充/并存
+    # 3. 低相似但过阈值 → 可能是相关但独立
+
+    if top["similarity"] >= 0.7:
+        # 高相似度：优先判断是否为「时间演进/迁移」类（如 Java→Go、AWS→阿里云）
+        # 这类语句明确指出旧事实已被取代，应走 UPDATE 而非 DELETE
+        transition_keywords = ["已从", "转向", "迁移", "改为", "全面", "切换到", "换成", "替代"]
+        is_transition = any(kw in new_fact for kw in transition_keywords)
+
+        # 否定词仅保留真正的「直接否定」语义，不再包含「已从/转向/改为」
+        # （后者是时间演进，不是逻辑否定）
+        negative_keywords = ["不", "不是", "没有", "不再", "讨厌", "不喜欢", "从不", "绝不"]
+        has_negation = any(kw in new_fact for kw in negative_keywords)
+
+        # 路由优先级：迁移 > 否定 > 细化
+        # 原因：迁移语句通常同时包含「转向」和「不」（如"已从 Java 转向 Go，不再用 Java"），
+        # 但语义上属于 UPDATE（保留 Java 作为历史版本），而非 DELETE
+        if is_transition:
+            return {
+                "action": "UPDATE",
+                "reason": f"时间演进/技术迁移：新事实替代已有记忆（相似度={top['similarity']:.2f}）",
+                "target_id": top["id"],
+                "candidates": candidates,
+            }
+
+        if has_negation and top["similarity"] >= 0.85:
+            return {
+                "action": "DELETE",
+                "reason": f"直接矛盾：新事实否定已有记忆（相似度={top['similarity']:.2f}）",
+                "target_id": top["id"],
+                "candidates": candidates,
+            }
+
+        return {
+            "action": "UPDATE",
+            "reason": f"细化/更新：新事实对已有记忆的补充（相似度={top['similarity']:.2f}）",
+            "target_id": top["id"],
+            "candidates": candidates,
+        }
+    elif top["similarity"] >= 0.5:
+        return {
+            "action": "ADD",
+            "reason": f"并存偏好：相关但不矛盾，并行保留（相似度={top['similarity']:.2f}）",
+            "candidates": candidates,
+        }
+    else:
+        return {
+            "action": "ADD",
+            "reason": f"弱相关：独立信息，新增（相似度={top['similarity']:.2f}）",
+            "candidates": candidates,
+        }
+
+
+def main():
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    fixtures_path = os.path.join(script_dir, "fixtures", "sample_memories.json")
+    with open(fixtures_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    memories = data["memories"]
+
+    # 测试用例：新事实 vs 已有记忆（覆盖四种路由：UPDATE / ADD / DELETE / 细化）
+    test_facts = [
+        # UPDATE（时间演进）：含「已从...转向」迁移词
+        "用户已从 Java 全面转向 Go 语言开发",
+        # ADD（并存偏好）：同主题但不矛盾，不构成否定
+        "用户喜欢尝试各种意大利菜，尤其偏爱意面",
+        # DELETE（直接矛盾）：含「讨厌」否定词，与 mem_007 直接对立
+        "用户非常讨厌披萨，从来不吃",
+        # UPDATE（细化补充）：补充 mem_006 的项目细节
+        "用户的电商项目涉及跨境支付和多币种结算",
+        # ADD（弱相关）：独立新信息
+        "用户正在考虑学习 Kubernetes",
+    ]
+
+    print("=" * 85)
+    print("X1-4 冲突检测与路由")
+    print(f"相似度阈值: 0.3（低于此值不进入候选）")
+    print(f"高冲突阈值: 0.7（高于此值触发 UPDATE/DELETE）")
+    print(f"{'=' * 85}")
+
+    for fact in test_facts:
+        print(f"\n{'-' * 85}")
+        print(f"新事实: 「{fact}」")
+        print(f"{'-' * 85}")
+
+        result = detect_conflict(fact, memories)
+
+        # 候选记忆
+        if result["candidates"]:
+            print(f"\n  候选已有记忆 ({len(result['candidates'])} 条)：")
+            for c in result["candidates"][:3]:
+                print(f"    [{c['id']}] (相似度={c['similarity']:.2f}) {c['content'][:60]}")
+
+        print(f"\n  路由决策: {result['action']}")
+        print(f"  原因: {result['reason']}")
+        if "target_id" in result:
+            target = next(m for m in memories if m["id"] == result["target_id"])
+            print(f"  操作对象: [{result['target_id']}] {target['content'][:60]}")
+
+    # 展示冲突检测的漏检/误报边界
+    print(f"\n{'=' * 85}")
+    print("阈值取舍分析")
+    print(f"{'=' * 85}")
+    print(f"  当前阈值: 0.3")
+    print(f"  如果阈值设太高（如 0.6）：")
+    print(f"    → 「用户考虑学 K8s」和「用户正在学 Rust」相似度约 0.3")
+    print(f"    → 阈值 0.6 时不会进入候选，但实际应该提醒「用户同时学两门新技术」")
+    print(f"  如果阈值设太低（如 0.1）：")
+    print(f"    → 大量不相关记忆进入候选，LLM 调用成本飙升")
+    print(f"    → 需要 LLM 精确判断，但成本与延迟不可接受")
+    print(f"  实践建议：0.25-0.35 起步，根据误报率和漏检率微调")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/code/X1/part1_decay_conflict/x1_5_conflict_resolve.py
+++ b/code/X1/part1_decay_conflict/x1_5_conflict_resolve.py
@@ -1,0 +1,216 @@
+"""
+x1_5_conflict_resolve.py — 冲突裁决执行：旧版失效、新版写入、版本追溯
+
+本脚本演示 x1_4 检测到冲突后, 如何实际修改记忆库:
+  1. UPDATE: 旧版标记 is_active=False (保留历史) → 新版写入，replaces 字段建立追溯链
+  2. DELETE: 不物理删除，标记 should_forget=True (检索时 ×0.1 降权，可回滚)
+  3. ADD: 直接新增
+
+三个场景演示:
+  - 技术栈变更 (Java→Go): UPDATE + 版本链追溯
+  - 并存偏好 (喜欢披萨+吃素): ADD，两条独立衰减
+  - 直接矛盾 (喜欢披萨→讨厌披萨): DELETE，标记遗忘
+
+运行:
+  python x1_5_conflict_resolve.py
+
+关键设计决策:
+  - UPDATE 不删旧版 → is_active=False 保留，replaces 字段链接新旧版本
+  - DELETE 不物理删除 → should_forget=True 只降权，用户纠正后可回滚
+  - 物理删除意味着不可恢复，标记遗忘 = 可逆
+
+对应正文: X1-1 §4.2 "裁决执行：留版本链，不物理删除"
+"""
+
+import json
+import os
+import copy
+from datetime import datetime
+
+
+def resolve_conflict(
+    memories_store: list,
+    new_fact: str,
+    action: str,
+    target_id: str | None,
+    importance_score: float = 0.5,
+    memory_type: str = "short_term",
+) -> dict:
+    """
+    执行冲突裁决，更新记忆库。
+    返回执行的操作摘要。
+    """
+    now = datetime.now().isoformat()
+    result = {
+        "action": action,
+        "new_fact": new_fact,
+        "timestamp": now,
+        "changes": [],
+    }
+
+    if action == "UPDATE" and target_id:
+        # 旧版标记为 inactive
+        for mem in memories_store:
+            if mem["id"] == target_id:
+                old_content = mem["content"]
+                mem["is_active"] = False
+                mem["updated_at"] = now
+                result["changes"].append({
+                    "type": "DEACTIVATE",
+                    "id": target_id,
+                    "old_content": old_content,
+                })
+                break
+
+        # 写入新版本
+        new_id = f"mem_{len(memories_store) + 1:03d}"
+        new_memory = {
+            "id": new_id,
+            "content": new_fact,
+            "importance_score": importance_score,
+            "memory_type": memory_type,
+            "created_at": now,
+            "last_reviewed": now,
+            "access_count": 0,
+            "is_active": True,
+            "replaces": target_id,
+        }
+        memories_store.append(new_memory)
+        result["changes"].append({
+            "type": "CREATE",
+            "id": new_id,
+            "content": new_fact,
+        })
+
+    elif action == "DELETE" and target_id:
+        for mem in memories_store:
+            if mem["id"] == target_id:
+                mem["is_active"] = False
+                mem["should_forget"] = True
+                mem["updated_at"] = now
+                result["changes"].append({
+                    "type": "MARK_FORGET",
+                    "id": target_id,
+                    "old_content": mem["content"],
+                })
+                break
+
+    elif action == "ADD":
+        new_id = f"mem_{len(memories_store) + 1:03d}"
+        new_memory = {
+            "id": new_id,
+            "content": new_fact,
+            "importance_score": importance_score,
+            "memory_type": memory_type,
+            "created_at": now,
+            "last_reviewed": now,
+            "access_count": 0,
+            "is_active": True,
+        }
+        memories_store.append(new_memory)
+        result["changes"].append({
+            "type": "CREATE",
+            "id": new_id,
+            "content": new_fact,
+        })
+
+    return result
+
+
+def show_memory_state(memories: list, title: str, filter_ids: list[str] | None = None):
+    """格式化展示记忆库状态"""
+    print(f"\n  [{title}]")
+    print(f"  {'ID':<10} {'Active':<8} {'Forget':<8} {'内容':<55}")
+    print(f"  {'-' * 80}")
+    for mem in memories:
+        if filter_ids and mem["id"] not in filter_ids:
+            continue
+        active = "[v]" if mem.get("is_active", True) else "[x]"
+        forget = "[v]" if mem.get("should_forget", False) else "[x]"
+        content = mem["content"][:52]
+        print(f"  {mem['id']:<10} {active:<8} {forget:<8} {content}")
+
+
+def main():
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    fixtures_path = os.path.join(script_dir, "fixtures", "sample_memories.json")
+    with open(fixtures_path, "r", encoding="utf-8") as f:
+        original_data = json.load(f)
+
+    # 使用深拷贝，避免修改原 fixtures
+    store = copy.deepcopy(original_data["memories"])
+
+    # 场景 1：技术栈变更 — UPDATE
+    print("=" * 85)
+    print("X1-5 冲突裁决执行")
+    print(f"{'=' * 85}")
+
+    print("\n场景 1：技术栈变更（UPDATE）")
+    print("  新事实: 「用户已从 Java 全面转向 Go 语言开发」")
+    print("  目标: mem_009（用户目前主要使用 Java 开发后端服务）")
+
+    related_ids = ["mem_009"]
+    show_memory_state(store, "操作前", related_ids)
+
+    result1 = resolve_conflict(
+        store,
+        "用户已从 Java 全面转向 Go 语言开发",
+        action="UPDATE",
+        target_id="mem_009",
+        importance_score=0.82,
+        memory_type="long_term",
+    )
+    new_id = next(c["id"] for c in result1["changes"] if c["type"] == "CREATE")
+    show_memory_state(store, "操作后", related_ids + [new_id])
+
+    # 场景 2：并存偏好 — ADD
+    print("\n场景 2：并存偏好（ADD）")
+    print("  新事实: 「用户最近在吃素，不吃任何肉类」")
+    print("  冲突: mem_007（用户最喜欢吃披萨）→ 但不是矛盾，并存")
+
+    related_ids2 = ["mem_007"]
+    show_memory_state(store, "操作前", related_ids2)
+
+    result2 = resolve_conflict(
+        store,
+        "用户最近在吃素，不吃任何肉类",
+        action="ADD",
+        target_id=None,
+        importance_score=0.50,
+    )
+    new_id2 = next(c["id"] for c in result2["changes"] if c["type"] == "CREATE")
+    show_memory_state(store, "操作后（两条并存）", related_ids2 + [new_id2])
+
+    # 场景 3：直接矛盾 — DELETE
+    print("\n场景 3：直接矛盾（DELETE）")
+    print("  新事实: 「用户非常讨厌披萨，从来不吃」")
+    print("  目标: mem_007（用户最喜欢吃披萨）→ 直接矛盾，删除旧的")
+
+    related_ids3 = ["mem_007"]
+    show_memory_state(store, "操作前", related_ids3)
+
+    result3 = resolve_conflict(
+        store,
+        "用户非常讨厌披萨，从来不吃",
+        action="DELETE",
+        target_id="mem_007",
+    )
+    show_memory_state(store, "操作后", related_ids3)
+    print(f"\n  注意：记忆未被物理删除，只是标记 should_forget=True、is_active=False")
+    print(f"  检索时 final_score 会乘以 forgotten_score_multiplier (0.1) 大幅降权")
+
+    # 展示最终状态
+    print(f"\n{'=' * 85}")
+    print("最终记忆库状态（涉及变更的记忆）")
+    changed_ids = ["mem_009", new_id, "mem_007", new_id2]
+    show_memory_state(store, "变更后", changed_ids)
+
+    print(f"\n  关键观察：")
+    print(f"    1. mem_009 (Java) → is_active=False，新记忆 {new_id} (Go) → is_active=True")
+    print(f"    2. mem_007 (喜欢披萨) → 场景 2 中保留，场景 3 中被标记遗忘")
+    print(f"    3. 历史版本不删除，可溯源 '用户什么时候开始用 Go？'")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/code/X1/part1_decay_conflict/x1_6_retrieval_aggregate.py
+++ b/code/X1/part1_decay_conflict/x1_6_retrieval_aggregate.py
@@ -1,0 +1,217 @@
+"""
+x1_6_retrieval_aggregate.py — 确定性聚合 vs 全量上下文
+
+当多条矛盾记忆同时被检索到, 有两种处理策略:
+  A. 确定性聚合: 代码层先合并（取最新 active 版本、过滤已失效的），结果一致可复现
+  B. 全量上下文: 所有候选记忆都塞进 Prompt 给 LLM 判断，灵活但不稳定
+
+运行:
+  python x1_6_retrieval_aggregate.py
+
+输出:
+  - 同一 query 下两种策略的返回结果对比
+  - 确定性聚合节省的 Token 估算
+  - 策略选择建议: 简单事实→确定性, 复杂偏好→全量上下文
+
+对应正文: X1-1 §4.3 "确定性聚合：检索之后、进 Prompt 之前"
+"""
+
+import json
+import os
+
+
+def load_data(filepath: str) -> dict:
+    with open(filepath, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def deterministic_aggregate(candidates: list, query: str) -> dict:
+    """
+    确定性聚合策略：
+    - 同一话题只返回最新 active 版本
+    - 多个话题分别返回各自的 active 版本
+    - 并存偏好全部返回但标注
+    """
+    # 按话题分组（简化：用关键词重叠判断话题）
+    topics = _group_by_topic(candidates)
+
+    aggregated = []
+    discarded = []
+
+    for topic_key, group in topics.items():
+        active_mems = [m for m in group if m.get("is_active", True)]
+        inactive_mems = [m for m in group if not m.get("is_active", True)]
+
+        if len(active_mems) == 1:
+            # 单个 active → 直接返回
+            aggregated.append(active_mems[0])
+            for im in inactive_mems:
+                discarded.append({
+                    "id": im["id"],
+                    "content": im["content"],
+                    "reason": f"已被 {active_mems[0]['id']} 取代",
+                })
+        elif len(active_mems) > 1:
+            # 多个 active → 并存偏好，全部保留
+            for am in active_mems:
+                aggregated.append(am)
+        elif inactive_mems:
+            # 只有 inactives → 返回最新的
+            latest = max(inactive_mems, key=lambda m: m.get("created_at", ""))
+            aggregated.append(latest)
+
+    return {
+        "strategy": "deterministic",
+        "results": aggregated,
+        "discarded": discarded,
+        "result_count": len(aggregated),
+    }
+
+
+def _group_by_topic(memories: list) -> dict:
+    """按话题分组（简化实现：用关键词重叠）"""
+    groups = {}
+    for mem in memories:
+        content = mem["content"]
+        # 提取主题词
+        topics_keywords = {
+            "编程语言": ["编程语言", "Java", "Go", "Python", "Rust", "开发"],
+            "食物偏好": ["吃", "披萨", "素", "食物", "饮食"],
+            "云平台": ["AWS", "阿里云", "云平台", "迁移"],
+            "编辑器": ["编辑器", "VS Code", "IDE"],
+            "电商项目": ["电商", "项目", "Django", "PostgreSQL"],
+        }
+
+        matched = "其他"
+        for topic, keywords in topics_keywords.items():
+            if any(kw in content for kw in keywords):
+                matched = topic
+                break
+
+        if matched not in groups:
+            groups[matched] = []
+        groups[matched].append(mem)
+
+    return groups
+
+
+def full_context_approach(candidates: list, query: str) -> dict:
+    """
+    全量上下文策略（模拟）：
+    把所有候选记忆都返回，估计 Token 消耗
+    """
+    total_chars = sum(len(c["content"]) for c in candidates)
+    estimated_tokens = total_chars * 0.5  # 粗略：中文约 2 字/token
+
+    return {
+        "strategy": "full_context",
+        "results": candidates,
+        "result_count": len(candidates),
+        "estimated_tokens": int(estimated_tokens),
+        "estimated_prompt_tokens": int(estimated_tokens + 200),  # 含 query 和指令
+    }
+
+
+def simulate_semantic_score(content: str, query: str) -> float:
+    """
+    模拟语义相似度分数（中文友好）。
+    实际系统中这是 embedding 余弦相似度，这里用主题关键词字典模拟。
+    """
+    topic_keywords = {
+        "编程语言": ["Python", "Java", "Go", "Rust", "编程", "语言", "开发", "后端", "主力", "框架"],
+        "食物偏好": ["吃", "披萨", "素", "食物", "饮食", "餐厅", "过敏", "花生", "肉类"],
+        "云平台": ["AWS", "阿里云", "云平台", "云服务", "云", "迁移"],
+        "编辑器": ["VS Code", "编辑器", "IDE", "插件"],
+        "电商项目": ["电商", "项目", "Django", "PostgreSQL", "技术栈"],
+        "代码风格": ["代码", "风格", "注释", "简洁"],
+        "学习": ["学", "教程", "初学者", "考虑"],
+    }
+
+    query_topics = [
+        topic for topic, keywords in topic_keywords.items()
+        if any(kw in query for kw in keywords)
+    ]
+    if not query_topics:
+        return 0.0
+
+    score = 0.0
+    for topic in query_topics:
+        keywords = topic_keywords[topic]
+        hits = sum(1 for kw in keywords if kw in content)
+        score += hits * 0.20
+    return min(1.0, score)
+
+
+def main():
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    fixtures_path = os.path.join(script_dir, "fixtures", "sample_memories.json")
+    data = load_data(fixtures_path)
+
+    print("=" * 85)
+    print("X1-6 检索结果聚合：确定性聚合 vs 全量上下文")
+    print(f"{'=' * 85}")
+
+    for q in data["queries"]:
+        print(f"\n{'-' * 85}")
+        print(f"查询: 「{q['query_text']}」")
+        print(f"{'-' * 85}")
+
+        # 模拟搜索：用主题关键词匹配圈定候选集
+        candidates = []
+        for mem in data["memories"]:
+            score = simulate_semantic_score(mem["content"], q["query_text"])
+            if score > 0:
+                candidates.append({**mem, "_sem_score": score})
+
+        # 策略 1：确定性聚合
+        det_result = deterministic_aggregate(candidates, q["query_text"])
+
+        # 策略 2：全量上下文
+        ctx_result = full_context_approach(candidates, q["query_text"])
+
+        print(f"\n  【策略 A：确定性聚合】返回 {det_result['result_count']} 条")
+        for r in det_result["results"]:
+            active_tag = "[v]" if r.get("is_active", True) else "[x]"
+            print(f"    [{r['id']}] (active={active_tag}) {r['content']}")
+        if det_result["discarded"]:
+            print(f"  已过滤 {len(det_result['discarded'])} 条：")
+            for d in det_result["discarded"]:
+                print(f"    [x] [{d['id']}] {d['content'][:50]} — {d['reason']}")
+
+        print(f"\n  【策略 B：全量上下文】返回 {ctx_result['result_count']} 条")
+        for r in ctx_result["results"]:
+            print(f"    [{r['id']}] {r['content'][:60]}")
+        print(f"  估计 Token 消耗: ~{ctx_result['estimated_tokens']} tokens（仅记忆内容）")
+        print(f"  含 Prompt 指令: ~{ctx_result['estimated_prompt_tokens']} tokens")
+
+        # 对比
+        det_chars = sum(len(r["content"]) for r in det_result["results"])
+        det_tokens = int(det_chars * 0.5)
+        token_diff = ctx_result["estimated_tokens"] - det_tokens
+        print(f"\n  对比：确定性聚合节省约 {max(0, token_diff)} tokens，且结果一致可复现")
+
+        # 检查是否符合预期
+        if "expected_answer_deterministic" in q:
+            print(f"  预期（确定性）: {q['expected_answer_deterministic']}")
+        if "expected_answer_context" in q:
+            print(f"  预期（上下文）: {q['expected_answer_context']}")
+        if "note" in q:
+            print(f"  注: {q['note']}")
+
+    # 总结
+    print(f"\n{'=' * 85}")
+    print("策略选择建议")
+    print(f"{'=' * 85}")
+    print(f"  确定性聚合适用场景：")
+    print(f"    - 简单事实查询（'用户用什么语言？'）")
+    print(f"    - 答案唯一、不需要 LLM 综合推理")
+    print(f"    - 对一致性要求高（同一问题两次返回必须相同）")
+    print(f"  全量上下文适用场景：")
+    print(f"    - 复杂偏好综合判断（'用户会喜欢这个方案吗？'）")
+    print(f"    - 需要 LLM 理解并存矛盾的上下文")
+    print(f"    - Token 预算充足、对一致性要求不高")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/code/X1/part2_namespace/README.md
+++ b/code/X1/part2_namespace/README.md
@@ -1,0 +1,17 @@
+# 中篇实验：记忆的边界与信任
+
+配套 [X1-2 记忆的边界与信任](../../../docs/extra/X1-2%20记忆的边界与信任.md)
+
+## 运行环境
+
+- Python 3.10+
+- 仅使用标准库（`json` / `threading` / `time` 等），无需额外安装
+
+## 实验列表
+
+| 序号 | 脚本 | 对应正文节 | 核心观察 |
+| --- | --- | --- | --- |
+| 7 | `x1_7_namespace_isolation.py` | §1.1 | 默认隔离，Agent 互不可见 |
+| 8 | `x1_8_promote_and_share.py` | §2.2 | promote 到 AGENT_GROUP 后同组可见，跨组仍不可见 |
+| 9 | `x1_9_cross_agent_query.py` | §1.1 | 查询阶段过滤 vs 检索后过滤的延迟差 |
+| 10 | `x1_10_concurrent_write.py` | §3.3 | 并发写冲突与乐观锁（CAS 重试） |

--- a/code/X1/part2_namespace/fixtures/agents.json
+++ b/code/X1/part2_namespace/fixtures/agents.json
@@ -1,0 +1,45 @@
+{
+  "agents": [
+    {
+      "agent_id": "agent_code_assistant",
+      "name": "代码助手",
+      "description": "帮助用户编写和调试代码",
+      "default_scope": "PRIVATE",
+      "agent_group": "dev_tools"
+    },
+    {
+      "agent_id": "agent_life_assistant",
+      "name": "生活助手",
+      "description": "帮助用户管理日常生活、饮食、健康建议",
+      "default_scope": "PRIVATE",
+      "agent_group": "life_tools"
+    },
+    {
+      "agent_id": "agent_finance_assistant",
+      "name": "财务助手",
+      "description": "帮助用户管理财务、投资建议",
+      "default_scope": "PRIVATE",
+      "agent_group": "life_tools"
+    },
+    {
+      "agent_id": "agent_project_manager",
+      "name": "项目管理助手",
+      "description": "帮助用户管理项目进度和团队协作",
+      "default_scope": "PRIVATE",
+      "agent_group": "dev_tools"
+    }
+  ],
+  "agent_groups": {
+    "dev_tools": {
+      "name": "开发工具组",
+      "members": ["agent_code_assistant", "agent_project_manager"],
+      "description": "所有开发相关的 Agent"
+    },
+    "life_tools": {
+      "name": "生活工具组",
+      "members": ["agent_life_assistant", "agent_finance_assistant"],
+      "description": "所有生活相关的 Agent"
+    }
+  },
+  "user_id": "user_001"
+}

--- a/code/X1/part2_namespace/fixtures/shared_profile.json
+++ b/code/X1/part2_namespace/fixtures/shared_profile.json
@@ -1,0 +1,52 @@
+{
+  "user_profile": {
+    "basic_info": {
+      "name": "张三",
+      "role": "高级后端工程师",
+      "company": "某电商公司",
+      "years_of_experience": 8
+    },
+    "tech_stack": {
+      "primary_language": "Go",
+      "secondary_languages": ["Python", "Rust"],
+      "framework": "Django",
+      "cloud": "阿里云",
+      "editor": "VS Code"
+    },
+    "preferences": {
+      "code_style": "简洁，不喜欢过多注释",
+      "learning_style": "动手实践优先",
+      "communication": "直接，喜欢要点式回答"
+    },
+    "health": {
+      "allergies": ["花生"],
+      "dietary": "近期在尝试素食"
+    }
+  },
+  "promotable_memories": [
+    {
+      "content": "用户是高级后端工程师，有 8 年经验",
+      "suggested_scope": "AGENT_GROUP",
+      "target_group": "dev_tools",
+      "reason": "技术身份信息，所有开发工具 Agent 需要知道"
+    },
+    {
+      "content": "用户偏好简洁的代码风格，不喜欢过多注释",
+      "suggested_scope": "AGENT_GROUP",
+      "target_group": "dev_tools",
+      "reason": "代码偏好，开发 Agent 共享"
+    },
+    {
+      "content": "用户对花生过敏",
+      "suggested_scope": "AGENT_GROUP",
+      "target_group": "life_tools",
+      "reason": "健康安全信息，生活类 Agent 需要知道"
+    },
+    {
+      "content": "用户最近在尝试素食",
+      "suggested_scope": "AGENT_GROUP",
+      "target_group": "life_tools",
+      "reason": "饮食偏好，生活类 Agent 共享"
+    }
+  ]
+}

--- a/code/X1/part2_namespace/x1_10_concurrent_write.py
+++ b/code/X1/part2_namespace/x1_10_concurrent_write.py
@@ -1,0 +1,230 @@
+"""
+x1_10_concurrent_write.py — 并发写入冲突与缓解策略
+
+两个 Agent 同时更新同一条用户画像字段, 会发生什么?
+
+三种策略对比:
+  1. no_lock:           直接覆盖, 后写入静默覆盖先写入 → 数据丢失
+  2. lww_timestamp:     最后写入胜出, 依赖时钟同步, NTP 误差可能导致意外行为
+  3. optimistic_lock:   乐观锁(version 字段), 写入时 CAS 检查, 冲突自动重试
+
+运行:
+  python x1_10_concurrent_write.py
+
+输出: 每种策略下两个 Agent 的写入结果和最终状态
+
+推荐: 乐观锁是最小成本的工程方案
+  - 不同 Agent 更新不同字段 → 各自独立, 无冲突
+  - 同一字段需要仲裁 → version + CAS + 最多 3 次重试
+
+对应正文: X1-2 §3.3 "乐观锁：共享画像的最小仲裁"
+"""
+
+import json
+import os
+import threading
+import time
+from datetime import datetime
+from typing import Any
+
+
+def simulate_concurrent_write(strategy: str = "no_lock") -> dict:
+    """
+    模拟两个线程（Agent）并发写入同一 key。
+
+    策略：
+    - no_lock: 无保护，后写入覆盖先写入（可能丢数据）
+    - optimistic_lock: 乐观锁（version 检查），冲突时重试
+    - lww_timestamp: 最后写入胜出（基于时间戳）
+    """
+
+    # 共享状态
+    shared_profile: dict[str, Any] = {
+        "preferred_language": "Java",
+        "version": 1,
+        "updated_at": "",  # 空字符串作为哨兵值，避免 LWW 首次比较时 str > None 报错
+        "updated_by": None,
+    }
+    write_log: list[dict] = []
+    lock = threading.Lock()
+
+    def agent_a_write():
+        """Agent A：用户已从 Java 转向 Go"""
+        time.sleep(0.01)  # 模拟网络延迟
+
+        if strategy == "no_lock":
+            # 直接覆盖，不管当前状态
+            shared_profile["preferred_language"] = "Go"
+            shared_profile["updated_by"] = "agent_code_assistant"
+            shared_profile["updated_at"] = datetime.now().isoformat()
+            write_log.append({"agent": "A (代码助手)", "content": "Go", "result": "written"})
+
+        elif strategy == "optimistic_lock":
+            # 乐观锁：读在锁外，写在锁内，模拟真实的读-改-写窗口
+            for attempt in range(3):
+                # 锁外读：记录读取时的 version
+                current_version = shared_profile["version"]
+                # 模拟读后处理（此时其他线程可能已修改 version）
+                time.sleep(0.05)
+                with lock:
+                    # CAS 检查：version 是否仍是读取时的值
+                    if shared_profile["version"] == current_version:
+                        shared_profile["preferred_language"] = "Go"
+                        shared_profile["version"] += 1
+                        shared_profile["updated_by"] = "agent_code_assistant"
+                        shared_profile["updated_at"] = datetime.now().isoformat()
+                        write_log.append({
+                            "agent": "A (代码助手)",
+                            "content": "Go",
+                            "result": f"written (v{shared_profile['version']}, attempts={attempt+1})",
+                        })
+                        break
+                    # version 已变 → 冲突，重试
+            else:
+                write_log.append({
+                    "agent": "A (代码助手)",
+                    "content": "Go",
+                    "result": "conflict_retry_failed (3 次重试均失败)",
+                })
+
+        elif strategy == "lww_timestamp":
+            ts = datetime.now().isoformat()
+            time.sleep(0.005)  # 确保时间戳有先后
+            with lock:
+                existing_ts = shared_profile.get("updated_at", "")
+                if ts > existing_ts:
+                    shared_profile["preferred_language"] = "Go"
+                    shared_profile["updated_by"] = "agent_code_assistant"
+                    shared_profile["updated_at"] = ts
+                    write_log.append({"agent": "A", "content": "Go", "result": "written (newer)"})
+                else:
+                    write_log.append({"agent": "A", "content": "Go", "result": "rejected (older)"})
+
+    def agent_b_write():
+        """Agent B：用户现在用 Rust 做主力"""
+        if strategy == "no_lock":
+            shared_profile["preferred_language"] = "Rust"
+            shared_profile["updated_by"] = "agent_project_manager"
+            shared_profile["updated_at"] = datetime.now().isoformat()
+            write_log.append({"agent": "B (PM助手)", "content": "Rust", "result": "written"})
+
+        elif strategy == "optimistic_lock":
+            for attempt in range(3):
+                current_version = shared_profile["version"]
+                time.sleep(0.05)
+                with lock:
+                    if shared_profile["version"] == current_version:
+                        shared_profile["preferred_language"] = "Rust"
+                        shared_profile["version"] += 1
+                        shared_profile["updated_by"] = "agent_project_manager"
+                        shared_profile["updated_at"] = datetime.now().isoformat()
+                        write_log.append({
+                            "agent": "B (PM助手)",
+                            "content": "Rust",
+                            "result": f"written (v{shared_profile['version']}, attempts={attempt+1})",
+                        })
+                        break
+            else:
+                write_log.append({
+                    "agent": "B (PM助手)",
+                    "content": "Rust",
+                    "result": "conflict_retry_failed (3 次重试均失败)",
+                })
+
+        elif strategy == "lww_timestamp":
+            ts = datetime.now().isoformat()
+            with lock:
+                existing_ts = shared_profile.get("updated_at", "")
+                if ts > existing_ts:
+                    shared_profile["preferred_language"] = "Rust"
+                    shared_profile["updated_by"] = "agent_project_manager"
+                    shared_profile["updated_at"] = ts
+                    write_log.append({"agent": "B", "content": "Rust", "result": "written (newer)"})
+                else:
+                    write_log.append({"agent": "B", "content": "Rust", "result": "rejected (older)"})
+
+    # 启动并发线程
+    t1 = threading.Thread(target=agent_a_write)
+    t2 = threading.Thread(target=agent_b_write)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    return {
+        "final_state": dict(shared_profile),
+        "write_log": write_log,
+    }
+
+
+def main():
+    print("=" * 85)
+    print("X1-10 并发写入冲突演示")
+    print("场景：Agent A（代码助手）和 Agent B（PM 助手）同时更新「用户编程语言偏好」")
+    print(f"{'=' * 85}")
+
+    strategies = [
+        ("no_lock", "无保护（直接覆盖）"),
+        ("lww_timestamp", "最后写入胜出（LWW）"),
+        ("optimistic_lock", "乐观锁（version 检查）"),
+    ]
+
+    for strategy, label in strategies:
+        print(f"\n{'-' * 85}")
+        print(f"策略: {label}")
+        print(f"{'-' * 85}")
+
+        result = simulate_concurrent_write(strategy)
+
+        for entry in result["write_log"]:
+            print(f"  {entry['agent']}: 写入 '{entry['content']}' → {entry['result']}")
+
+        final = result["final_state"]
+        print(f"\n  最终状态：preferred_language = '{final['preferred_language']}'")
+        print(f"  更新者：{final['updated_by']}")
+
+        if strategy == "no_lock":
+            if final["preferred_language"] in ("Go", "Rust"):
+                print(f"  [!] 问题：两个写入中丢失了一个！用户偏好是 '{final['preferred_language']}'，"
+                      f"但另一个 Agent 的写入被无声覆盖。")
+                print(f"    更糟的是——我们不知道哪个是'正确的'，后到的覆盖了先到的。")
+
+        elif strategy == "lww_timestamp":
+            print(f"  注意：LWW 保证了确定性（时间戳更大的胜出），但不保证正确性。")
+            print(f"  如果 Agent A 的更新更准确但时钟慢了 1ms，正确数据就丢了。")
+
+        elif strategy == "optimistic_lock":
+            # 检查两条是否都写入成功
+            both_written = all("written" in e["result"] for e in result["write_log"])
+            # attempts > 1 才算真正经历过 CAS 冲突重试
+            import re as _re
+            retry_count = sum(
+                1 for e in result["write_log"]
+                if "attempts=" in e["result"] and int(_re.search(r"attempts=(\d+)", e["result"]).group(1)) > 1
+            )
+            if both_written:
+                print(f"  [v] 乐观锁 + CAS 重试：两个写入最终都成功")
+                if retry_count > 0:
+                    print(f"    其中 {retry_count} 个写入经历了「读到旧版本 → CAS 失败 → 重试」过程")
+                print(f"    version 从 1 → {final['version']}，每次自增对应一次成功的 CAS")
+            else:
+                print(f"  [!] 重试失败，一个写入被拒绝（需要业务层处理）")
+
+    # 结论
+    print(f"\n{'=' * 85}")
+    print("总结与建议")
+    print(f"{'=' * 85}")
+    print(f"  1. 无保护写入在多 Agent 场景下不可接受——数据会静默丢失。")
+    print(f"  2. LWW 实现简单但依赖时钟同步，NTP 误差可能导致意外行为。")
+    print(f"  3. 乐观锁（version）是最小成本的工程方案：")
+    print(f"     - 写入时携带当前 version，服务端检查 CAS")
+    print(f"     - 冲突时自动重试（最多 3 次）")
+    print(f"     - version chain 提供完整的变更历史")
+    print(f"  4. 对于用户画像类字段（结构化、单值），建议：")
+    print(f"     - 不同 Agent 更新不同字段 → 各自独立，无冲突")
+    print(f"     - 同一字段需要仲裁 → 乐观锁 + 冲突时通知用户")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/code/X1/part2_namespace/x1_7_namespace_isolation.py
+++ b/code/X1/part2_namespace/x1_7_namespace_isolation.py
@@ -1,0 +1,183 @@
+"""
+x1_7_namespace_isolation.py — 命名空间隔离验证
+
+本脚本验证多 Agent 记忆最基础的安全属性: 默认相互不可见。
+
+模拟 PowerMem 的三级隔离键:
+  user_id: 用户维度的隔离（一级）
+  agent_id: Agent 维度的隔离（二级）
+  run_id:   会话维度的隔离（三级）
+
+运行:
+  python x1_7_namespace_isolation.py
+
+实验设计:
+  - Agent A (代码助手) 写入 3 条技术相关记忆
+  - Agent B (生活助手) 写入 2 条生活相关记忆
+  - 验证 Agent A 搜索"饮食 过敏"时，看不到 Agent B 的记忆
+
+关键设计决策: 查询构建阶段就注入过滤条件
+  这是 PowerMem _build_db_filters 的设计哲学——过滤发生在数据库索引层，
+  而不是在应用代码中过滤全量搜索结果。
+
+对应正文: X1-2 §1.1 "命名空间：三个字段决定谁能看到什么"
+"""
+
+import json
+import os
+from datetime import datetime
+from typing import Any
+
+
+class NamespaceMemoryStore:
+    """
+    模拟带命名空间隔离的记忆存储。
+    实际 PowerMem 中这通过 _SYSTEM_FILTER_KEYS 在 SQL WHERE 子句中实现。
+    """
+
+    def __init__(self):
+        self._store: list[dict[str, Any]] = []
+
+    def add(
+        self,
+        content: str,
+        user_id: str,
+        agent_id: str,
+        run_id: str = "default",
+        scope: str = "PRIVATE",
+        importance: float = 0.5,
+    ) -> str:
+        """写入记忆，带完整的命名空间标记"""
+        mem_id = f"mem_{len(self._store) + 1:03d}"
+        memory = {
+            "id": mem_id,
+            "content": content,
+            "user_id": user_id,
+            "agent_id": agent_id,
+            "run_id": run_id,
+            "scope": scope,
+            "importance_score": importance,
+            "created_at": datetime.now().isoformat(),
+            "is_active": True,
+        }
+        self._store.append(memory)
+        return mem_id
+
+    def search(
+        self,
+        query: str,
+        user_id: str,
+        agent_id: str,
+        scope_filter: list[str] | None = None,
+    ) -> list:
+        """
+        检索记忆。关键：user_id + agent_id 在查询构建阶段就注入过滤条件。
+        这与 PowerMem 的 _build_db_filters 设计一致。
+        """
+        results = []
+        query_lower = query.lower()
+
+        for mem in self._store:
+            # 命名空间隔离：只返回当前 agent 的记忆
+            if mem["user_id"] != user_id:
+                continue
+            if mem["agent_id"] != agent_id:
+                continue
+            if scope_filter and mem["scope"] not in scope_filter:
+                continue
+            if not mem["is_active"]:
+                continue
+
+            # 简单的关键词匹配模拟语义搜索
+            content_lower = mem["content"].lower()
+            keywords = query_lower.split()
+            relevance = sum(1 for kw in keywords if kw in content_lower) / max(len(keywords), 1)
+
+            if relevance > 0:
+                results.append({**mem, "relevance": relevance})
+
+        results.sort(key=lambda x: x["relevance"], reverse=True)
+        return results
+
+    def get_all_for_user(self, user_id: str) -> list:
+        """获取某用户的所有记忆（仅用于调试对比）"""
+        return [m for m in self._store if m["user_id"] == user_id]
+
+
+def main():
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    fixtures_path = os.path.join(script_dir, "fixtures", "agents.json")
+    with open(fixtures_path, "r", encoding="utf-8") as f:
+        config = json.load(f)
+
+    user_id = config["user_id"]
+    store = NamespaceMemoryStore()
+
+    print("=" * 85)
+    print("X1-7 命名空间隔离验证")
+    print(f"用户: {user_id}")
+    print(f"{'=' * 85}")
+
+    # Agent A (代码助手) 写入记忆
+    agent_a = config["agents"][0]  # agent_code_assistant
+    store.add("用户正在用 Go 开发微服务，需要 gRPC 相关的帮助",
+              user_id, agent_a["agent_id"])
+    store.add("用户偏好使用 VS Code，已配置 Go 开发环境",
+              user_id, agent_a["agent_id"])
+    store.add("用户的代码风格偏好：简洁、不喜欢过多注释",
+              user_id, agent_a["agent_id"])
+    print(f"\n  {agent_a['name']} ({agent_a['agent_id']}) 写入了 3 条记忆")
+
+    # Agent B (生活助手) 写入记忆
+    agent_b = config["agents"][1]  # agent_life_assistant
+    store.add("用户对花生过敏，所有饮食建议必须避开",
+              user_id, agent_b["agent_id"])
+    store.add("用户最近在尝试素食，推荐素食餐厅",
+              user_id, agent_b["agent_id"])
+    print(f"  {agent_b['name']} ({agent_b['agent_id']}) 写入了 2 条记忆")
+
+    # 验证隔离
+    print(f"\n{'-' * 85}")
+    print("隔离验证：Agent A 检索自己的记忆")
+    print(f"{'-' * 85}")
+    results_a = store.search("开发 编程", user_id, agent_a["agent_id"])
+    for r in results_a:
+        print(f"  [{r['id']}] (scope={r['scope']}) {r['content']}")
+    print(f"  共 {len(results_a)} 条 → Agent A 只能看到自己的记忆")
+
+    print(f"\n{'-' * 85}")
+    print("隔离验证：Agent B 检索自己的记忆")
+    print(f"{'-' * 85}")
+    results_b = store.search("饮食 健康", user_id, agent_b["agent_id"])
+    for r in results_b:
+        print(f"  [{r['id']}] (scope={r['scope']}) {r['content']}")
+    print(f"  共 {len(results_b)} 条 → Agent B 只能看到自己的记忆")
+
+    # 交叉验证：Agent A 尝试查看 Agent B 的记忆
+    print(f"\n{'-' * 85}")
+    print("交叉验证：Agent A 搜索「饮食 过敏」（Agent B 的记忆领域）")
+    print(f"{'-' * 85}")
+    cross_results = store.search("饮食 过敏 素食", user_id, agent_a["agent_id"])
+    if not cross_results:
+        print(f"  (无结果) → 正确！Agent A 看不到 Agent B 的记忆")
+    else:
+        print(f"  [!] 泄漏！Agent A 看到了 {len(cross_results)} 条不属于它的记忆")
+
+    # 全量视图（调试用）
+    print(f"\n{'-' * 85}")
+    print("全量记忆清单（仅用于调试对比，生产环境不会有此接口）")
+    print(f"{'-' * 85}")
+    all_mems = store.get_all_for_user(user_id)
+    print(f"  {'Agent':<25} {'Scope':<10} {'内容':<45}")
+    print(f"  {'-' * 80}")
+    for m in all_mems:
+        print(f"  {m['agent_id']:<25} {m['scope']:<10} {m['content'][:42]}")
+
+    print(f"\n  关键观察：同一个 user_id 下有 5 条记忆，")
+    print(f"  但每个 Agent 只能检索到属于自己的那部分。")
+    print(f"  agent_id 作为检索过滤条件，在查询构建阶段就已注入。")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/code/X1/part2_namespace/x1_8_promote_and_share.py
+++ b/code/X1/part2_namespace/x1_8_promote_and_share.py
@@ -1,0 +1,249 @@
+"""
+x1_8_promote_and_share.py — 权限提升与跨 Agent 共享
+
+本脚本演示: 如何安全地将一条 PRIVATE 记忆 promote 到 AGENT_GROUP, 让同组其他 Agent 可见。
+
+PowerMem 的 scope 层级设计 (只能向更开放的方向 promote):
+  PRIVATE(0)  ──promote──>  AGENT_GROUP(1)  ──promote──>  PUBLIC(2)
+
+运行:
+  python x1_8_promote_and_share.py
+
+实验设计:
+  - 代码助手(dev_tools 组) 写入技术偏好 → PRIVATE
+  - 验证 PM 助手(dev_tools 组) 看不到
+  - promote 到 AGENT_GROUP(dev_tools) → PM 助手现在可检索
+  - 验证生活助手(life_tools 组) 仍然看不到 dev_tools 组的记忆
+  - 审计日志: 所有 promote 操作都有时间+操作者记录
+
+对应正文: X1-2 §2.2 "Promote：只能向更开放的方向移动"
+"""
+
+import json
+import os
+from datetime import datetime
+from typing import Any
+
+
+SCOPE_LEVEL = {"PRIVATE": 0, "AGENT_GROUP": 1, "USER_GROUP": 2, "PUBLIC": 3}
+
+
+class MemoryWithScope:
+    """带作用域管理和 ACL 的记忆存储"""
+
+    def __init__(self, agents_config: dict):
+        self._store: list[dict[str, Any]] = []
+        self._agents = agents_config["agents"]
+        self._groups = agents_config["agent_groups"]
+        self._audit_log: list[dict] = []
+
+    def add(self, content: str, user_id: str, agent_id: str, scope: str = "PRIVATE") -> str:
+        mem_id = f"mem_{len(self._store) + 1:03d}"
+        self._store.append({
+            "id": mem_id,
+            "content": content,
+            "user_id": user_id,
+            "agent_id": agent_id,
+            "scope": scope,
+            "created_at": datetime.now().isoformat(),
+            "is_active": True,
+            "scope_history": [{"scope": scope, "changed_at": datetime.now().isoformat()}],
+        })
+        return mem_id
+
+    def promote(
+        self,
+        memory_id: str,
+        new_scope: str,
+        target_group: str | None = None,
+        actor_id: str = "user",
+    ) -> bool:
+        """
+        Promote 记忆到更高作用域。
+        PowerMem 的规则：只能向更严格的方向（数值更大）移动。
+        """
+        for mem in self._store:
+            if mem["id"] == memory_id:
+                old_scope = mem["scope"]
+                if SCOPE_LEVEL.get(new_scope, 0) <= SCOPE_LEVEL.get(old_scope, 0):
+                    print(f"    [!] 不能从 {old_scope} promote 到 {new_scope}（只能向更开放的方向）")
+                    return False
+
+                mem["scope"] = new_scope
+                if target_group:
+                    mem["target_group"] = target_group
+                mem["scope_history"].append({
+                    "scope": new_scope,
+                    "changed_at": datetime.now().isoformat(),
+                    "actor": actor_id,
+                })
+
+                self._audit_log.append({
+                    "memory_id": memory_id,
+                    "old_scope": old_scope,
+                    "new_scope": new_scope,
+                    "actor": actor_id,
+                    "timestamp": datetime.now().isoformat(),
+                })
+                return True
+        return False
+
+    def search_for_agent(
+        self,
+        query: str,
+        user_id: str,
+        agent_id: str,
+    ) -> list:
+        """
+        检索时考虑 scope：
+        - PRIVATE: 仅 owner agent 可见
+        - AGENT_GROUP: owner + 同组 agent 可见
+        - PUBLIC: 所有 agent 可见
+        """
+        agent_info = next((a for a in self._agents if a["agent_id"] == agent_id), None)
+        agent_group = agent_info["agent_group"] if agent_info else None
+
+        results = []
+        query_lower = query.lower()
+
+        for mem in self._store:
+            if mem["user_id"] != user_id:
+                continue
+            if not mem["is_active"]:
+                continue
+
+            # Scope 可见性判断
+            if mem["scope"] == "PRIVATE" and mem["agent_id"] != agent_id:
+                continue  # 其他 agent 看不到 PRIVATE
+            if mem["scope"] == "AGENT_GROUP":
+                target_group = mem.get("target_group", "")
+                if mem["agent_id"] != agent_id and agent_group != target_group:
+                    continue  # 不在同一组
+            # PUBLIC 不做限制
+
+            # 简单关键词匹配
+            content_lower = mem["content"].lower()
+            keywords = query_lower.split()
+            relevance = sum(1 for kw in keywords if kw in content_lower) / max(len(keywords), 1)
+
+            if relevance > 0:
+                results.append({**mem, "relevance": relevance})
+
+        results.sort(key=lambda x: x["relevance"], reverse=True)
+        return results
+
+    def get_audit_log(self, memory_id: str | None = None) -> list:
+        if memory_id:
+            return [e for e in self._audit_log if e["memory_id"] == memory_id]
+        return self._audit_log
+
+
+def main():
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    with open(os.path.join(script_dir, "fixtures", "agents.json"), "r", encoding="utf-8") as f:
+        config = json.load(f)
+    with open(os.path.join(script_dir, "fixtures", "shared_profile.json"), "r", encoding="utf-8") as f:
+        profile = json.load(f)
+
+    user_id = config["user_id"]
+    store = MemoryWithScope(config)
+
+    print("=" * 85)
+    print("X1-8 权限提升与共享")
+    print(f"{'=' * 85}")
+
+    # 场景设置：代码助手写入技术偏好（PRIVATE）
+    agent_dev = config["agents"][0]  # agent_code_assistant (dev_tools group)
+    agent_pm = config["agents"][3]   # agent_project_manager (dev_tools group)
+    agent_life = config["agents"][1]  # agent_life_assistant (life_tools group)
+
+    mid1 = store.add(
+        "用户是高级后端工程师，主力语言 Go，有 8 年经验",
+        user_id, agent_dev["agent_id"], scope="PRIVATE"
+    )
+    mid2 = store.add(
+        "用户偏好简洁的代码风格，不喜欢过多注释",
+        user_id, agent_dev["agent_id"], scope="PRIVATE"
+    )
+    mid3 = store.add(
+        "用户对花生过敏，所有食物建议必须避开",
+        user_id, agent_life["agent_id"], scope="PRIVATE"
+    )
+    print(f"\n初始状态：3 条记忆均为 PRIVATE")
+
+    # Promote 前：PM Agent 看不到代码助手的记忆
+    print(f"\n{'-' * 85}")
+    print("Promote 前：项目管理助手搜索「代码 风格」")
+    print(f"{'-' * 85}")
+    results_before = store.search_for_agent("代码 风格 技术栈", user_id, agent_pm["agent_id"])
+    if not results_before:
+        print(f"  (无结果) → 正确！PM Agent 看不到代码助手的 PRIVATE 记忆")
+    else:
+        for r in results_before:
+            print(f"  [{r['id']}] {r['content']}")
+
+    # Promote：技术身份 → AGENT_GROUP (dev_tools)
+    print(f"\n{'-' * 85}")
+    print("Promote 操作")
+    print(f"{'-' * 85}")
+    for promo in profile["promotable_memories"][:2]:  # 前两条是 dev_tools 的
+        # 用「关键字符重合度」做匹配，避免子串不一致导致 promote 失败
+        # 取 promo.content 中前 8 个字符作为指纹（足够区分不同记忆）
+        promo_fingerprint = promo["content"][:8]
+        target_mem = next(
+            (m for m in store._store
+             if promo_fingerprint in m["content"]  # 用前缀匹配，允许中间有插入语
+             and m["agent_id"] == agent_dev["agent_id"]),
+            None,
+        )
+        if target_mem:
+            ok = store.promote(
+                target_mem["id"],
+                promo["suggested_scope"],
+                promo["target_group"],
+                actor_id="user",
+            )
+            if ok:
+                print(f"  [v] [{target_mem['id']}] {promo['suggested_scope']} "
+                      f"(target={promo['target_group']}) ← {promo['reason']}")
+        else:
+            print(f"  [!] 未找到匹配记忆：{promo['content']}")
+
+    # Promote 后：PM Agent 现在能看到代码助手的 AGENT_GROUP 记忆
+    print(f"\n{'-' * 85}")
+    print("Promote 后：项目管理助手搜索「代码 风格」")
+    print(f"{'-' * 85}")
+    results_after = store.search_for_agent("代码 风格 技术栈", user_id, agent_pm["agent_id"])
+    for r in results_after:
+        print(f"  [{r['id']}] (scope={r['scope']}) {r['content']}")
+    print(f"  共 {len(results_after)} 条 → PM Agent 现在可以看到同组的 AGENT_GROUP 记忆")
+
+    # 跨组验证：生活助手看不到 dev_tools 组的记忆
+    print(f"\n{'-' * 85}")
+    print("跨组验证：生活助手搜索「代码 风格 技术栈」")
+    print(f"{'-' * 85}")
+    cross_results = store.search_for_agent("代码 风格 技术栈", user_id, agent_life["agent_id"])
+    if not cross_results:
+        print(f"  (无结果) → 正确！life_tools 组的 Agent 看不到 dev_tools 组的记忆")
+    else:
+        for r in cross_results:
+            print(f"  [{r['id']}] {r['content']}")
+
+    # 审计日志
+    print(f"\n{'-' * 85}")
+    print("审计日志")
+    print(f"{'-' * 85}")
+    for entry in store.get_audit_log():
+        print(f"  [{entry['timestamp'][:19]}] {entry['memory_id']}: "
+              f"{entry['old_scope']} → {entry['new_scope']} (by {entry['actor']})")
+
+    print(f"\n  关键观察：")
+    print(f"    1. 记忆默认 PRIVATE，写入后仅 owner Agent 可见")
+    print(f"    2. promote 到 AGENT_GROUP 后，同组 Agent 可检索")
+    print(f"    3. 跨 Agent Group 不可见（life_tools 看不到 dev_tools 的记忆）")
+    print(f"    4. scope 变更全程记录审计日志，可追溯 '谁、何时、为什么'")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/code/X1/part2_namespace/x1_9_cross_agent_query.py
+++ b/code/X1/part2_namespace/x1_9_cross_agent_query.py
@@ -1,0 +1,153 @@
+"""
+x1_9_cross_agent_query.py — 查询构建阶段过滤 vs 检索后过滤
+
+两种实现命名空间隔离的方式, 在性能、安全和正确性上有本质差异:
+  A. 查询阶段过滤 (PowerMem 采用): WHERE 子句直接注入 user_id + agent_id
+     → 数据库索引层过滤，无关数据不离开数据库，延迟低
+  B. 检索后过滤: 全量搜索 → 应用代码中筛掉不属于当前 namespace 的数据
+     → 大量无效数据被拉到应用层再丢弃，延迟高且可能泄漏到日志
+
+运行:
+  python x1_9_cross_agent_query.py
+
+输出:
+  - 多规模 (100 ~ 10000 条) 下两种策略的耗时对比
+  - 正确性验证: 两种策略结果是否一致
+  - 安全性对比: 哪种方式更不容易泄漏敏感数据
+
+对应正文: X1-2 §1.1 "命名空间：三个字段决定谁能看到什么"
+"""
+
+import json
+import os
+import time
+import random
+from datetime import datetime
+
+
+def create_test_data(num_memories: int = 1000, num_agents: int = 10) -> list:
+    """生成大规模测试数据"""
+    memories = []
+    topics = ["编程", "饮食", "健康", "旅行", "财务", "音乐", "运动", "读书", "游戏", "摄影"]
+    for i in range(num_memories):
+        topic = random.choice(topics)
+        agent_idx = random.randint(0, num_agents - 1)
+        memories.append({
+            "id": f"mem_{i:05d}",
+            "content": f"用户{topic}相关的偏好或事实 #{i}",
+            "user_id": "user_001",
+            "agent_id": f"agent_{agent_idx:02d}",
+            "topic": topic,
+            "is_active": True,
+        })
+    return memories
+
+
+def filter_at_query_time(memories: list, user_id: str, agent_id: str, query: str) -> tuple:
+    """
+    查询构建阶段过滤（PowerMem 的方式）。
+    WHERE 条件在搜索前已确定，搜索只命中目标子集。
+    """
+    start = time.perf_counter()
+
+    # 模拟：先过滤再搜索（实际是 WHERE 子句直接限制索引范围）
+    filtered = [m for m in memories if m["user_id"] == user_id and m["agent_id"] == agent_id]
+
+    # 在过滤后的子集上搜索
+    results = []
+    for m in filtered:
+        if any(kw in m["content"] for kw in query.split()):
+            results.append(m)
+
+    elapsed = time.perf_counter() - start
+    return results, elapsed, len(filtered)
+
+
+def filter_after_retrieval(memories: list, user_id: str, agent_id: str, query: str) -> tuple:
+    """
+    检索后过滤（不推荐的方式）。
+    先全量搜索，再从结果中过滤不属于当前 namespace 的。
+    """
+    start = time.perf_counter()
+
+    # 全量搜索
+    all_results = []
+    for m in memories:
+        if any(kw in m["content"] for kw in query.split()):
+            all_results.append(m)
+
+    # 再过滤
+    results = [m for m in all_results
+               if m["user_id"] == user_id and m["agent_id"] == agent_id]
+
+    elapsed = time.perf_counter() - start
+    return results, elapsed, len(all_results)
+
+
+def main():
+    print("=" * 85)
+    print("X1-9 查询构建阶段过滤 vs 检索后过滤")
+    print(f"{'=' * 85}")
+
+    scales = [100, 500, 1000, 5000, 10000]
+    target_agent = "agent_05"
+    user_id = "user_001"
+    query = "编程 偏好"
+
+    print(f"\n  目标 Agent: {target_agent}")
+    print(f"  查询: 「{query}」")
+    print(f"\n  {'规模':<10} {'策略':<20} {'搜索子集':<10} {'耗时':<15} {'结果数':<8}")
+    print(f"  {'-' * 65}")
+
+    for scale in scales:
+        memories = create_test_data(scale, num_agents=10)
+
+        # 策略 1：查询阶段过滤
+        results1, elapsed1, subset_size = filter_at_query_time(
+            memories, user_id, target_agent, query
+        )
+
+        # 策略 2：检索后过滤
+        results2, elapsed2, full_search_size = filter_after_retrieval(
+            memories, user_id, target_agent, query
+        )
+
+        speedup = elapsed2 / elapsed1 if elapsed1 > 0 else float("inf")
+
+        print(f"  {scale:<10} {'查询阶段过滤':<20} {subset_size}/{scale:<7} "
+              f"{elapsed1*1000:8.3f}ms  {len(results1):<8}")
+        print(f"  {'':10} {'检索后过滤':<20} {full_search_size}/{scale:<7} "
+              f"{elapsed2*1000:8.3f}ms  {len(results2):<8} "
+              f"(×{speedup:.1f})")
+
+    # 正确性验证
+    print(f"\n{'-' * 85}")
+    print("正确性验证（规模=1000）")
+    print(f"{'-' * 85}")
+    test_data = create_test_data(1000, num_agents=10)
+    r1, _, _ = filter_at_query_time(test_data, user_id, target_agent, "编程")
+    r2, _, _ = filter_after_retrieval(test_data, user_id, target_agent, "编程")
+
+    ids1 = set(m["id"] for m in r1)
+    ids2 = set(m["id"] for m in r2)
+    if ids1 == ids2:
+        print(f"  [v] 两种策略结果一致（{len(ids1)} 条）")
+    else:
+        print(f"  [!] 结果不一致！差异: {ids1 ^ ids2}")
+
+    # 安全性对比
+    print(f"\n{'-' * 85}")
+    print("安全性对比")
+    print(f"{'-' * 85}")
+    print(f"  查询阶段过滤：")
+    print(f"    → 不属于当前 namespace 的数据从未离开数据库")
+    print(f"    → 即使日志记录查询语句，也不会泄漏其他 Agent 的数据")
+    print(f"  检索后过滤：")
+    print(f"    → 全量搜索结果经过应用层，可能被日志、异常堆栈捕获")
+    print(f"    → 如果过滤代码有 bug，敏感数据可能意外返回给调用方")
+    print(f"  结论：查询构建阶段过滤是安全基础，不是性能优化。")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/code/X1/part3_consolidation/README.md
+++ b/code/X1/part3_consolidation/README.md
@@ -1,0 +1,18 @@
+# 下篇实验：从记忆到认知
+
+配套 [X1-3 从记忆到认知](../../../docs/extra/X1-3%20从记忆到认知.md)
+
+## 运行环境
+
+- Python 3.10+
+- 仅使用标准库（`math` / `json` / `random` 等），无需额外安装
+
+## 实验列表
+
+| 序号 | 脚本 | 对应正文节 | 核心观察 |
+| --- | --- | --- | --- |
+| 11 | `x1_11_consolidation_passive.py` | §2.1 | 高重要性记忆直通长期层（被动巩固） |
+| 12 | `x1_12_consolidation_reflection.py` | §2.2 | 多条短期记忆蒸馏为稳定事实（主动巩固） |
+| 13 | `x1_13_profile_vs_facts.py` | §3 | 画像 + 事实库组合检索 |
+| 14 | `x1_14_experience_distill.py` | §4 | 经验三元组 → Skill 雏形 |
+| 15 | `x1_15_benchmark_runner.py` | §5.2 | 多策略评测对比（准确率 / Token / 延迟） |

--- a/code/X1/part3_consolidation/fixtures/eval_qa_pairs.json
+++ b/code/X1/part3_consolidation/fixtures/eval_qa_pairs.json
@@ -1,0 +1,90 @@
+{
+  "qa_pairs": [
+    {
+      "id": "q001",
+      "question": "用户目前主要使用什么编程语言？",
+      "expected_answer": "Go",
+      "relevant_memories": ["mem_010", "mem_009"],
+      "category": "事实记忆",
+      "difficulty": "easy"
+    },
+    {
+      "id": "q002",
+      "question": "用户对什么食物过敏？",
+      "expected_answer": "花生",
+      "relevant_memories": ["mem_004"],
+      "category": "安全关键",
+      "difficulty": "easy"
+    },
+    {
+      "id": "q003",
+      "question": "用户在学什么新技术？",
+      "expected_answer": "Rust",
+      "relevant_memories": ["mem_003"],
+      "category": "事实记忆",
+      "difficulty": "easy"
+    },
+    {
+      "id": "q004",
+      "question": "用户当前的云平台是什么？",
+      "expected_answer": "阿里云",
+      "relevant_memories": ["mem_012", "mem_011"],
+      "category": "冲突解决",
+      "difficulty": "medium"
+    },
+    {
+      "id": "q005",
+      "question": "用户的饮食偏好是什么？",
+      "expected_answer": "披萨、素",
+      "relevant_memories": ["mem_007", "mem_008"],
+      "category": "并存偏好",
+      "difficulty": "medium"
+    },
+    {
+      "id": "q006",
+      "question": "推荐一个适合用户的后端技术方案",
+      "expected_answer": "Go、微服务、阿里云",
+      "relevant_memories": ["mem_010", "mem_012", "mem_001"],
+      "category": "综合推理",
+      "difficulty": "hard"
+    },
+    {
+      "id": "q007",
+      "question": "用户的代码风格偏好是什么？",
+      "expected_answer": "简洁、注释",
+      "relevant_memories": ["mem_002"],
+      "category": "偏好记忆",
+      "difficulty": "easy"
+    },
+    {
+      "id": "q008",
+      "question": "用户之前在用什么语言开发？",
+      "expected_answer": "Java",
+      "relevant_memories": ["mem_009"],
+      "category": "历史追溯",
+      "difficulty": "medium"
+    }
+  ],
+  "strategies_to_evaluate": [
+    {
+      "name": "no_decay",
+      "description": "不使用衰减，仅语义排序",
+      "params": {"decay_rate": 100}
+    },
+    {
+      "name": "default_decay",
+      "description": "默认衰减参数（λ=1.5）",
+      "params": {"decay_rate": 1.5}
+    },
+    {
+      "name": "aggressive_decay",
+      "description": "激进衰减（λ=5.0）",
+      "params": {"decay_rate": 5.0}
+    },
+    {
+      "name": "conservative_decay",
+      "description": "保守衰减（λ=0.5）",
+      "params": {"decay_rate": 0.5}
+    }
+  ]
+}

--- a/code/X1/part3_consolidation/fixtures/reflection_input.json
+++ b/code/X1/part3_consolidation/fixtures/reflection_input.json
@@ -1,0 +1,79 @@
+{
+  "recent_memories": [
+    {
+      "id": "r001",
+      "content": "用户今天在 Stack Overflow 上查 Rust 生命周期（lifetime）的问题",
+      "timestamp": "2026-01-20T10:00:00",
+      "category": "情景记忆",
+      "topic": "Rust 学习"
+    },
+    {
+      "id": "r002",
+      "content": "用户下载了 Rust 官方教程，开始从第一章系统学习",
+      "timestamp": "2026-01-21T14:00:00",
+      "category": "情景记忆",
+      "topic": "Rust 学习"
+    },
+    {
+      "id": "r003",
+      "content": "用户搭建了 Rust 开发环境，安装了 rustup 和 VSCode Rust 插件",
+      "timestamp": "2026-01-22T09:00:00",
+      "category": "情景记忆",
+      "topic": "Rust 学习"
+    },
+    {
+      "id": "r004",
+      "content": "用户询问了 Django ORM 的 N+1 查询优化问题",
+      "timestamp": "2026-01-22T16:00:00",
+      "category": "情景记忆",
+      "topic": "Python 开发"
+    },
+    {
+      "id": "r005",
+      "content": "用户使用 Django + PostgreSQL 成功处理了 100 万行 CSV 数据导入",
+      "timestamp": "2026-01-23T11:00:00",
+      "category": "情景记忆",
+      "topic": "Python 开发"
+    },
+    {
+      "id": "r006",
+      "content": "用户对比了 Rust 和 Go 的并发模型，认为 Rust 的 ownership 概念有学习曲线但值得投入",
+      "timestamp": "2026-01-24T15:00:00",
+      "category": "情景记忆",
+      "topic": "Rust 学习"
+    },
+    {
+      "id": "r007",
+      "content": "用户上周开始每天 6 点起床跑步，坚持了一整周",
+      "timestamp": "2026-01-25T07:00:00",
+      "category": "情景记忆",
+      "topic": "生活习惯"
+    },
+    {
+      "id": "r008",
+      "content": "用户周末去了三家素食餐厅，对其中一家的素食披萨评价很高",
+      "timestamp": "2026-01-25T19:00:00",
+      "category": "情景记忆",
+      "topic": "饮食偏好"
+    },
+    {
+      "id": "r009",
+      "content": "用户询问了 Rust Web 框架选型：Actix-web vs Axum",
+      "timestamp": "2026-01-26T10:00:00",
+      "category": "情景记忆",
+      "topic": "Rust 学习"
+    },
+    {
+      "id": "r010",
+      "content": "用户用 Axum 搭建了第一个 REST API，觉得比预期简单",
+      "timestamp": "2026-01-27T16:00:00",
+      "category": "情景记忆",
+      "topic": "Rust 学习"
+    }
+  ],
+  "reflection_config": {
+    "min_related_count": 3,
+    "time_window_days": 14,
+    "min_confidence": 0.6
+  }
+}

--- a/code/X1/part3_consolidation/fixtures/user_profile.json
+++ b/code/X1/part3_consolidation/fixtures/user_profile.json
@@ -1,0 +1,40 @@
+{
+  "profile": {
+    "identity": {
+      "name": "张三",
+      "role": "高级后端工程师",
+      "years_of_experience": 8,
+      "company_type": "电商"
+    },
+    "tech_stack": {
+      "primary_language": "Go",
+      "secondary_languages": ["Python", "Rust（学习中）"],
+      "framework_preference": "简洁轻量",
+      "database": "PostgreSQL",
+      "cloud": "阿里云"
+    },
+    "preferences": {
+      "code_style": "简洁，不喜欢过多注释",
+      "communication": "直接，要点式回答",
+      "learning_style": "动手实践优先于理论"
+    },
+    "health_and_safety": {
+      "allergies": ["花生"],
+      "dietary": "近期在尝试素食"
+    },
+    "current_context": {
+      "project": "电商平台后端重构",
+      "learning": "Rust（系统学习阶段）",
+      "exercise": "每天晨跑"
+    }
+  },
+  "vector_facts": [
+    {"content": "用户的电商项目涉及跨境支付和多币种结算", "category": "项目细节"},
+    {"content": "用户之前用 Java 开发，2026年1月全面转向 Go", "category": "技术变迁"},
+    {"content": "用户用 Django + PostgreSQL 成功处理了 100 万行 CSV 数据导入", "category": "成功经验"},
+    {"content": "用户使用 Axum 框架搭建了第一个 Rust REST API", "category": "技术实践"},
+    {"content": "用户对比了 Rust 和 Go 的并发模型", "category": "技术探索"},
+    {"content": "用户周末去了三家素食餐厅，喜欢素食披萨", "category": "饮食偏好"},
+    {"content": "用户坚持每天 6 点晨跑，已持续一周", "category": "生活习惯"}
+  ]
+}

--- a/code/X1/part3_consolidation/x1_11_consolidation_passive.py
+++ b/code/X1/part3_consolidation/x1_11_consolidation_passive.py
@@ -1,0 +1,151 @@
+"""
+x1_11_consolidation_passive.py — 被动巩固：高重要性直通长期层
+
+本脚本演示记忆巩固的第一种触发方式: 被动触发 (写入时分流)。
+
+PowerMem 的 _classify_memory_type 在写入瞬间完成分层:
+  importance ≥ 0.8 → long_term (衰减倍率 ×60, 接近"永久记忆")
+  0.6 ≤ importance < 0.8 → short_term (衰减倍率 ×7, 中等持久)
+  importance < 0.6 → working (衰减倍率 ×1, 几天内自然淘汰)
+
+运行:
+  python x1_11_consolidation_passive.py
+
+输出:
+  - 6 条不同重要性的记忆各自进入哪个层级
+  - 长期层 vs 临时层在写入后 1d/7d/30d/90d/365d 的衰减曲线对比
+  - 被动巩固的局限性: 只能基于单条记忆, 无法发现"多条短期记忆凑一起=重要"的模式
+
+对应正文: X1-3 §2.1 "被动触发：写入时的一次分流"
+"""
+
+import math
+from datetime import datetime, timedelta
+
+
+# PowerMem 源码参数
+DECAY_RATE = 1.5
+DECAY_RATE_MULTIPLIERS = {"working": 1, "short_term": 7, "long_term": 60}
+LONG_TERM_THRESHOLD = 0.8
+SHORT_TERM_THRESHOLD = 0.6
+NOW = datetime(2026, 2, 1, 12, 0, 0)
+
+
+def classify_memory_type(importance_score: float) -> str:
+    """模拟 PowerMem _classify_memory_type"""
+    if importance_score >= LONG_TERM_THRESHOLD:
+        return "long_term"
+    if importance_score >= SHORT_TERM_THRESHOLD:
+        return "short_term"
+    return "working"
+
+
+def calculate_retention(
+    created_at: datetime,
+    memory_type: str,
+    access_count: int,
+    current_time: datetime = NOW,
+) -> float:
+    """计算保留率 R = e^(-t / (24*S))，t 为 created_at 到 current_time 的小时数"""
+    hours_elapsed = (current_time - created_at).total_seconds() / 3600
+    multiplier = DECAY_RATE_MULTIPLIERS[memory_type]
+    reinforcement = math.log1p(access_count)
+    strength = DECAY_RATE * multiplier * (1 + reinforcement)
+    return max(0.0, min(1.0, math.exp(-hours_elapsed / (24 * strength))))
+
+
+def main():
+    print("=" * 85)
+    print("X1-11 被动巩固：高重要性直通长期层")
+    print(f"{'=' * 85}")
+
+    # 不同重要性的记忆写入（带模拟的 access_count，让保留率更贴近真实场景）
+    test_memories = [
+        # (内容, 重要性, access_count) —— access_count 模拟「30 天里被检索过几次」
+        ("用户对花生过敏，所有食物建议必须避开", 0.95, 8),
+        ("用户是高级后端工程师，主力语言 Go，8 年经验", 0.85, 5),
+        ("用户正在做的电商项目使用 Django + PostgreSQL", 0.72, 3),
+        ("用户偏好简洁的代码风格，不喜欢过多注释", 0.65, 2),
+        ("用户最近在考虑学习 Kubernetes", 0.55, 0),
+        ("用户今天早上喝了咖啡", 0.20, 0),
+    ]
+
+    print(f"\n  重要性阈值: long_term ≥ {LONG_TERM_THRESHOLD}, "
+          f"short_term ≥ {SHORT_TERM_THRESHOLD}")
+    print(f"  写入时间: {NOW.strftime('%Y-%m-%d %H:%M')}")
+    print(f"\n  {'内容':<50} {'重要性':<8} {'层级':<12} {'30天后保留率':<15}")
+    print(f"  {'-' * 85}")
+
+    consolidated = []  # 被巩固到长期层的记忆
+
+    # 模拟"30 天后"再算保留率：把当前时间推到 30 天后
+    future_now = NOW + timedelta(days=30)
+
+    for content, importance, access in test_memories:
+        mem_type = classify_memory_type(importance)
+        # 被动巩固：写入瞬间就决定了层级
+        created = NOW
+        # 用 future_now 作为"当前时间"，算"写入后 30 天的保留率"
+        retention_30d = calculate_retention(
+            created, mem_type, access_count=access, current_time=future_now
+        )
+
+        marker = ""
+        if mem_type == "long_term":
+            marker = " * 直通长期层"
+            consolidated.append(content)
+
+        print(f"  {content:<50} {importance:<8.2f} {mem_type:<12} "
+              f"{retention_30d:.4f} ({retention_30d*100:.1f}%){marker}")
+
+    # 展示长期层 vs 临时层的衰减差异
+    print(f"\n{'-' * 85}")
+    print("长期层 vs 临时层：写入后各时间点的保留率对比")
+    print(f"{'-' * 85}")
+
+    time_points = [
+        ("写入时", NOW),
+        ("1 天后", NOW + timedelta(days=1)),
+        ("7 天后", NOW + timedelta(days=7)),
+        ("30 天后", NOW + timedelta(days=30)),
+        ("90 天后", NOW + timedelta(days=90)),
+        ("365 天后", NOW + timedelta(days=365)),
+    ]
+
+    def _bar(value: float, width: int = 15) -> str:
+        filled = int(value * width)
+        return "#" * filled + "." * (width - filled)
+
+    print(f"\n  {'时间点':<15} {'长期层 (花生过敏)':<25} {'临时层 (喝咖啡)':<25}")
+    print(f"  {'-' * 65}")
+    for label, tp in time_points:
+        r_long = calculate_retention(NOW, "long_term", 0, current_time=tp)
+        r_work = calculate_retention(NOW, "working", 0, current_time=tp)
+        print(f"  {label:<15} {r_long:.4f} {_bar(r_long):<15}  "
+              f"{r_work:.4f} {_bar(r_work):<15}")
+
+    # 用真实公式值替换之前硬编码的错误数字
+    r_long_30d = calculate_retention(NOW, "long_term", 0, current_time=NOW + timedelta(days=30))
+    r_long_90d = calculate_retention(NOW, "long_term", 0, current_time=NOW + timedelta(days=90))
+    r_work_1d = calculate_retention(NOW, "working", 0, current_time=NOW + timedelta(days=1))
+    r_work_7d = calculate_retention(NOW, "working", 0, current_time=NOW + timedelta(days=7))
+
+    # 结论
+    print(f"\n{'-' * 85}")
+    print("关键观察")
+    print(f"{'-' * 85}")
+    print(f"  1. 写入瞬间完成分层：高重要性（≥{LONG_TERM_THRESHOLD}）直通长期层")
+    print(f"  2. 长期层即使 access_count=0，30 天后 R ≈ {r_long_30d:.2f}，"
+          f"90 天后仍有 R ≈ {r_long_90d:.2f}——安全关键信息能长期维持可召回状态")
+    print(f"  3. 临时层 1 天后 R ≈ {r_work_1d:.2f}，7 天后 R ≈ {r_work_7d:.4f}——"
+          f"低价值信息几天内即被自然淘汰")
+    print(f"  4. 「对花生过敏」这种安全关键信息自动进入长期层，不会被快速遗忘")
+    print(f"  5. 中期层若被频繁检索（access_count 高）可让 R 回升——这是访问强化的效果；")
+    print(f"     但单纯靠访问无法把临时层升级到长期层的衰减速度")
+    print(f"  6. 被动巩固的局限：只能基于单条记忆的重要性判断，")
+    print(f"     无法发现「多条短期记忆隐含一个稳定事实」的模式 → 需要主动 reflection")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/code/X1/part3_consolidation/x1_12_consolidation_reflection.py
+++ b/code/X1/part3_consolidation/x1_12_consolidation_reflection.py
@@ -1,0 +1,194 @@
+"""
+x1_12_consolidation_reflection.py — Reflection 蒸馏：从多条短期记忆中发现稳定事实
+
+本脚本演示记忆巩固的第二种触发方式: 主动触发 (周期性 reflection)。
+
+与 x1_11 的被动巩固不同, reflection 不看单条记忆的重要性, 而是扫描近期记忆,
+发现"多条短期记忆凑在一起隐含一个重要事实"的模式:
+  例: "看 Rust 教程" + "问生命周期问题" + "搭建 Rust 环境"
+      → 蒸馏为 "用户正在系统学习 Rust, 是初学者"
+
+运行:
+  python x1_12_consolidation_reflection.py
+
+输入: fixtures/reflection_input.json (10 条近期记忆, 覆盖 4 个话题)
+输出:
+  - 按话题分组的结果 ("Rust 学习" 5 条, "Python 开发" 2 条...)
+  - 每个话题的蒸馏结果和置信度
+  - 压缩比: 原始记忆数 vs 蒸馏后长期事实数
+  - 置信度未达标的记忆保留在中期层, 等待更多证据
+
+关键参数:
+  min_count = 3: 至少 3 条相关记忆才能触发蒸馏 (避免单条孤证)
+  min_confidence = 0.7: 置信度达标才写入长期层
+
+对应正文: X1-3 §2.2 "主动触发：Reflection 蒸馏"
+"""
+
+import json
+import os
+from datetime import datetime, timedelta
+from collections import defaultdict
+
+
+NOW = datetime(2026, 2, 1, 12, 0, 0)
+
+
+def group_by_topic(memories: list) -> dict:
+    """按话题关键词分组"""
+    topic_keywords = {
+        "Rust 学习": ["Rust", "rustup", "Axum", "Actix", "ownership", "lifetime"],
+        "Python 开发": ["Python", "Django", "pandas", "ORM", "CSV"],
+        "生活习惯": ["跑步", "晨跑", "早起", "运动"],
+        "饮食偏好": ["素食", "披萨", "餐厅", "饮食"],
+    }
+
+    groups = defaultdict(list)
+    for mem in memories:
+        for topic, keywords in topic_keywords.items():
+            if any(kw in mem["content"] for kw in keywords):
+                groups[topic].append(mem)
+                break
+        else:
+            groups["其他"].append(mem)
+
+    return dict(groups)
+
+
+def reflection_analyze(
+    topic: str,
+    memories: list,
+    min_count: int = 3,
+    min_confidence: float = 0.7,
+) -> dict | None:
+    """
+    模拟 LLM reflection：分析同一话题的多条记忆，蒸馏为稳定事实。
+
+    实际系统中这一步骤由 LLM 完成：
+    "以下是用户最近关于 {topic} 的记忆：[memories]
+     请判断这些记忆是否隐含一个稳定的用户事实或偏好。
+     如果是，用一句话总结。"
+
+    这里用规则模拟 LLM 的输出。
+
+    参数:
+      min_count: 至少几条相关记忆才触发蒸馏
+      min_confidence: 置信度阈值，达到才标记 consolidate_to_long_term
+    """
+    if len(memories) < min_count:
+        return None
+
+    # 模拟 LLM 蒸馏逻辑
+    patterns = {
+        "Rust 学习": {
+            "keywords_check": ["教程", "环境", "框架", "教程", "API"],
+            "distilled_fact": "用户正在系统学习 Rust 语言，已搭建开发环境并使用 Axum 框架实践，目前处于初学者阶段",
+            "confidence": 0.85,
+            "supporting_evidence": len(memories),
+        },
+        "Python 开发": {
+            "keywords_check": ["Django", "Python", "ORM"],
+            "distilled_fact": "用户具备 Django 开发能力，能独立处理 ORM 优化和大数据量导入",
+            "confidence": 0.75,
+            "supporting_evidence": len(memories),
+        },
+        "生活习惯": {
+            "keywords_check": ["跑步", "晨跑"],
+            "distilled_fact": "用户坚持每天晨跑，已形成稳定习惯",
+            "confidence": 0.70 if len(memories) >= 3 else 0.40,
+            "supporting_evidence": len(memories),
+        },
+        "饮食偏好": {
+            "keywords_check": ["素食", "餐厅"],
+            "distilled_fact": "用户持续尝试素食，偏好素食披萨等创意素食",
+            "confidence": 0.65 if len(memories) >= 2 else 0.35,
+            "supporting_evidence": len(memories),
+        },
+    }
+
+    if topic in patterns:
+        p = patterns[topic]
+        confidence = p["confidence"]
+        return {
+            "topic": topic,
+            "distilled_fact": p["distilled_fact"],
+            "confidence": confidence,
+            "supporting_count": len(memories),
+            "source_memories": [m["id"] for m in memories],
+            "action": "consolidate_to_long_term" if confidence >= min_confidence else "keep_in_short_term",
+        }
+
+    return None
+
+
+def main():
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    fixtures_path = os.path.join(script_dir, "fixtures", "reflection_input.json")
+    with open(fixtures_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    memories = data["recent_memories"]
+    config = data["reflection_config"]
+
+    print("=" * 85)
+    print("X1-12 Reflection 蒸馏")
+    print(f"输入: {len(memories)} 条近期记忆")
+    print(f"Reflection 配置: 最少关联数={config['min_related_count']}, "
+          f"时间窗口={config['time_window_days']}天, 最小置信度={config['min_confidence']}")
+    print(f"{'=' * 85}")
+
+    # Step 1: 按话题分组
+    groups = group_by_topic(memories)
+    print(f"\n步骤 1：按话题分组")
+    for topic, mems in groups.items():
+        print(f"  [{topic}] {len(mems)} 条记忆")
+        for m in mems:
+            print(f"    - [{m['id']}] {m['content'][:60]}...")
+
+    # Step 2: 对每组执行 reflection
+    print(f"\n步骤 2：Reflection 分析")
+    consolidated = []
+    for topic, mems in groups.items():
+        result = reflection_analyze(
+            topic, mems,
+            min_count=config["min_related_count"],
+            min_confidence=config["min_confidence"],
+        )
+        if result:
+            status = "[v] 蒸馏为长期事实" if result["action"] == "consolidate_to_long_term" else "○ 保留在中期层"
+            print(f"\n  [{topic}] → {status}")
+            print(f"    蒸馏结果: {result['distilled_fact']}")
+            print(f"    置信度: {result['confidence']:.2f}")
+            print(f"    支撑证据: {result['supporting_count']} 条记忆 ({', '.join(result['source_memories'])})")
+            if result["confidence"] >= config["min_confidence"]:
+                consolidated.append(result)
+        else:
+            print(f"\n  [{topic}] → 跳过（只有 {len(mems)} 条记忆，不足 {config['min_related_count']} 条）")
+
+    # Step 3: 展示蒸馏效果
+    print(f"\n{'-' * 85}")
+    print("步骤 3：蒸馏前后对比")
+    print(f"{'-' * 85}")
+    total_original = len(memories)
+    total_distilled = len(consolidated)
+    print(f"  原始记忆: {total_original} 条")
+    print(f"  蒸馏后稳定事实: {total_distilled} 条")
+    print(f"  压缩比: {total_original}:{total_distilled} "
+          f"({total_original/total_distilled:.1f}:1)" if total_distilled > 0 else "")
+
+    if consolidated:
+        print(f"\n  进入长期层的事实：")
+        for c in consolidated:
+            print(f"    * [{c['topic']}] {c['distilled_fact']} (置信度={c['confidence']:.2f})")
+
+    print(f"\n  关键观察：")
+    print(f"    1. Reflection 是「从多条记忆中发现模式」的过程")
+    print(f"    2. 不是所有话题都有足够的证据形成稳定事实")
+    print(f"    3. 置信度门槛（如 0.7）决定了哪些进入长期层")
+    print(f"    4. 蒸馏后的事实比原始记忆更抽象、更稳定、衰减更慢")
+    print(f"    5. 实际系统中 Reflection 通过 LLM 完成，规则模拟仅作演示")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/code/X1/part3_consolidation/x1_13_profile_vs_facts.py
+++ b/code/X1/part3_consolidation/x1_13_profile_vs_facts.py
@@ -1,0 +1,227 @@
+"""
+x1_13_profile_vs_facts.py — 画像 + 事实库组合检索
+
+本脚本演示论文中关键的架构决策: 为什么要把"用户画像"和"向量事实库"分开存储?
+
+对比三种检索方式:
+  A. 仅画像 (精确读取): 快、准，但覆盖不到画像字段之外的长尾信息
+  B. 仅事实库 (语义搜索): 广、长尾，但确定性信息可能被语义模糊匹配漏掉
+  C. 组合检索: 画像提供确定性约束 + 事实库提供上下文补充 → 最完整
+
+运行:
+  python x1_13_profile_vs_facts.py
+
+输入: fixtures/user_profile.json (结构化画像 + 向量事实列表)
+输出:
+  - 4 个不同查询下三种方式的返回结果对比
+  - 组合检索的设计原则总结
+
+对应正文: X1-3 §3 "画像与事实库为什么要分开"
+"""
+
+import json
+import os
+from typing import Any
+
+
+def load_profile(filepath: str) -> dict:
+    with open(filepath, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def query_profile_only(profile: dict, query: str) -> dict:
+    """仅从画像中查询，返回匹配的字段"""
+    flat_profile = {}
+
+    def flatten(d, prefix=""):
+        for k, v in d.items():
+            key = f"{prefix}.{k}" if prefix else k
+            if isinstance(v, dict):
+                flatten(v, key)
+            elif isinstance(v, list):
+                flat_profile[key] = ", ".join(str(x) for x in v)
+            else:
+                flat_profile[key] = str(v)
+
+    flatten(profile["profile"])
+
+    # 用主题关键词字典识别 query 涉及的话题（中文友好）
+    query_keywords = _extract_query_keywords(query)
+
+    results = {}
+    for key, value in flat_profile.items():
+        # 任一查询关键词出现在 key 或 value 中即视为命中
+        if any(kw in key.lower() or kw in value.lower() for kw in query_keywords):
+            results[key] = value
+    return results
+
+
+def _extract_query_keywords(query: str) -> list[str]:
+    """
+    从 query 中提取相关关键词。
+    返回的 keywords 既包含中文话题词，也包含对应的英文桥接词（用来匹配 profile 的英文 key）。
+    例如 query 含"编程语言" → 返回 ['编程', '语言', 'language', 'Python', 'Java', 'Go', 'Rust']
+    """
+    # 主题词典：每条 topic 包含 (a) 中文/英文触发词（用来判断 query 是否涉及该主题）
+    #         (b) 桥接词（一旦确定涉及，就把这些都当成 query 关键词）
+    topic_keywords = {
+        "编程语言": {
+            "triggers": ["编程", "语言", "开发", "后端", "主力", "框架", "Python", "Java", "Go", "Rust"],
+            "bridges": ["编程", "语言", "开发", "后端", "主力", "框架",
+                        "language", "framework", "Python", "Java", "Go", "Rust"],
+        },
+        "食物偏好": {
+            "triggers": ["吃", "披萨", "素", "食物", "饮食", "餐厅", "过敏", "花生", "肉类"],
+            "bridges": ["吃", "披萨", "素", "食物", "饮食", "餐厅", "过敏", "花生", "肉类",
+                        "dietary", "allergies", "food"],
+        },
+        "云平台": {
+            "triggers": ["AWS", "阿里云", "云平台", "云服务", "云", "迁移"],
+            "bridges": ["AWS", "阿里云", "云平台", "云服务", "云", "迁移", "cloud"],
+        },
+        "编辑器": {
+            "triggers": ["VS Code", "编辑器", "IDE", "插件"],
+            "bridges": ["VS Code", "编辑器", "IDE", "插件", "editor"],
+        },
+        "电商项目": {
+            "triggers": ["电商", "项目", "Django", "PostgreSQL", "技术栈"],
+            "bridges": ["电商", "项目", "Django", "PostgreSQL", "技术栈", "project"],
+        },
+        "代码风格": {
+            "triggers": ["代码", "风格", "注释", "简洁"],
+            "bridges": ["代码", "风格", "注释", "简洁", "code_style"],
+        },
+        "健康": {
+            "triggers": ["健康", "过敏", "花生", "注意事项", "饮食"],
+            "bridges": ["健康", "过敏", "花生", "注意事项", "饮食",
+                        "health", "allergies", "dietary"],
+        },
+        "技术方案": {
+            "triggers": ["技术", "方案", "推荐", "适合", "微服务"],
+            "bridges": ["技术", "方案", "推荐", "适合", "微服务", "后端"],
+        },
+        "学习": {
+            "triggers": ["学", "教程", "初学者", "考虑", "学习"],
+            "bridges": ["学", "教程", "初学者", "考虑", "学习", "learning"],
+        },
+    }
+
+    matched_topics = [
+        topic for topic, mapping in topic_keywords.items()
+        if any(tr in query for tr in mapping["triggers"])
+    ]
+
+    keywords = []
+    for topic in matched_topics:
+        keywords.extend(topic_keywords[topic]["bridges"])
+
+    # fallback：如果主题词典没匹配上，按字符级 fallback 取 ≥2 字符的中文片段
+    if not keywords:
+        import re
+        cn_chunks = re.findall(r'[一-鿿]{2,}', query)
+        keywords.extend(cn_chunks)
+
+    return keywords
+
+
+def query_facts_only(facts: list, query: str) -> list:
+    """仅从事实库语义搜索（模拟）"""
+    query_keywords = _extract_query_keywords(query)
+
+    results = []
+    for fact in facts:
+        content = fact["content"]
+        if not query_keywords:
+            continue
+        hits = sum(1 for kw in query_keywords if kw in content)
+        if hits == 0:
+            continue
+        score = hits / max(len(query_keywords), 1)
+        results.append({"content": fact["content"], "score": score, "category": fact["category"]})
+    results.sort(key=lambda x: x["score"], reverse=True)
+    return results[:5]
+
+
+def query_combined(profile: dict, facts: list, query: str) -> dict:
+    """组合检索：先画像，后事实库"""
+    profile_results = query_profile_only(profile, query)
+    fact_results = query_facts_only(facts, query)
+    return {
+        "deterministic": profile_results,  # 确定性约束
+        "contextual": fact_results,         # 上下文补充
+    }
+
+
+def main():
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    fixtures_path = os.path.join(script_dir, "fixtures", "user_profile.json")
+    profile_data = load_profile(fixtures_path)
+
+    queries = [
+        "用户用什么编程语言",
+        "推荐一个适合用户的后端技术方案",
+        "用户有什么健康注意事项",
+        "用户最近在忙什么项目",
+    ]
+
+    print("=" * 85)
+    print("X1-13 画像 + 事实库组合检索")
+    print(f"{'=' * 85}")
+
+    for query in queries:
+        print(f"\n{'-' * 85}")
+        print(f"查询: 「{query}」")
+        print(f"{'-' * 85}")
+
+        # 方式 1：仅画像
+        profile_only = query_profile_only(profile_data, query)
+        print(f"\n  【方式 A：仅画像】返回 {len(profile_only)} 个字段")
+        if profile_only:
+            for k, v in profile_only.items():
+                print(f"    {k}: {v}")
+        else:
+            print(f"    (无匹配 → 纯画像查询信息不足)")
+
+        # 方式 2：仅事实库
+        facts_only = query_facts_only(profile_data["vector_facts"], query)
+        print(f"\n  【方式 B：仅事实库】返回 {len(facts_only)} 条")
+        for f in facts_only:
+            print(f"    [{f['category']}] (相关度={f['score']:.2f}) {f['content']}")
+
+        # 方式 3：组合
+        combined = query_combined(profile_data, profile_data["vector_facts"], query)
+        print(f"\n  【方式 C：组合检索】")
+        print(f"    确定性约束（画像）: {len(combined['deterministic'])} 个字段")
+        for k, v in combined["deterministic"].items():
+            print(f"      {k}: {v}")
+        print(f"    上下文补充（事实库）: {len(combined['contextual'])} 条")
+        for f in combined["contextual"]:
+            print(f"      [{f['category']}] {f['content']}")
+
+        # 分析
+        print(f"\n  分析：")
+        if not profile_only and facts_only:
+            print(f"    → 画像无匹配，但事实库有 {len(facts_only)} 条相关。")
+            print(f"    → 纯画像查询会漏掉这些长尾信息。")
+        elif profile_only and not facts_only:
+            print(f"    → 画像能提供确定性答案，事实库无额外补充。")
+            print(f"    → 仅画像就够，不需要消耗事实库检索的 Token。")
+        elif profile_only and facts_only:
+            print(f"    → 画像提供确定性约束，事实库提供上下文细节。")
+            print(f"    → 组合效果 > 各自单独使用。")
+
+    # 总结
+    print(f"\n{'=' * 85}")
+    print("组合检索的设计原则")
+    print(f"{'=' * 85}")
+    print(f"  1. 画像优先：确定性信息从画像中按 key 直接读取，不经过语义匹配")
+    print(f"     → 避免 '用户是 Go 开发者' 因语义模糊被漏掉")
+    print(f"  2. 事实库补充：长尾信息、情景记忆通过语义搜索从事实库获取")
+    print(f"     → 覆盖画像字段以外的丰富上下文")
+    print(f"  3. 最终 Prompt = 画像字段(确定性) + 事实库 Top-N(补充)")
+    print(f"     → 确定性信息确保准确，语义补充确保全面")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/code/X1/part3_consolidation/x1_14_experience_distill.py
+++ b/code/X1/part3_consolidation/x1_14_experience_distill.py
@@ -1,0 +1,229 @@
+"""
+x1_14_experience_distill.py — 情景记忆 → 经验三元组 → Skill 雏形
+
+本脚本演示 X1 系列与 P4/X2 的核心衔接点: 记忆系统的输出如何成为 Skill 系统的输入。
+
+三步流程:
+  1. 提取: 从情景记忆中结构化提取 (问题, 方案, 结果) 三元组
+  2. 聚类: 同类成功经验聚合 → 归纳为可复用的经验模式
+  3. 外化: 经验模式 → Skill 描述 → 可注入 System Prompt 的行为规则
+
+运行:
+  python x1_14_experience_distill.py
+
+输入: 8 条内置情景记忆 (覆盖数据处理、Web 框架、部署运维、学习路径)
+输出:
+  - 每条情景记忆的结构化三元组
+  - 按领域聚类的经验模式及置信度
+  - 高置信度模式 → Skill 描述
+
+闭环意义:
+  记忆系统"记住偏好" → 蒸馏为经验 → 外化为 Skill
+  Agent 从被动记住进化到主动适应
+
+对应正文: X1-3 §4 "从经验到 Skill"
+"""
+
+import json
+from typing import Any
+from collections import defaultdict
+
+
+def extract_experience_triples(episodic_memories: list) -> list:
+    """
+    从情景记忆中提取经验三元组：(问题情境, 采取方案, 结果)
+
+    实际系统中由 LLM 完成：
+    "从以下交互记录中提取 (问题, 方案, 结果) 三元组"
+    """
+    triples = []
+    for mem in episodic_memories:
+        triple = {
+            "source_id": mem["id"],
+            "problem": mem.get("problem", ""),
+            "solution": mem.get("solution", ""),
+            "result": mem.get("result", ""),
+            "success": "成功" in mem.get("result", "") or "效果好" in mem.get("result", ""),
+            "domain": mem.get("domain", "通用"),
+        }
+        triples.append(triple)
+    return triples
+
+
+def cluster_experiences(triples: list) -> dict:
+    """按领域聚类经验，归纳为经验模式"""
+    by_domain = defaultdict(list)
+    for t in triples:
+        if t["success"]:
+            by_domain[t["domain"]].append(t)
+
+    patterns = {}
+    for domain, exp_list in by_domain.items():
+        if len(exp_list) >= 2:  # 至少两条同类经验才能形成模式
+            # 模拟 LLM 归纳
+            pattern = _induce_pattern(domain, exp_list)
+            patterns[domain] = pattern
+
+    return patterns
+
+
+def _induce_pattern(domain: str, experiences: list) -> dict:
+    """模拟 LLM 从同类经验中归纳模式"""
+    templates = {
+        "数据处理": {
+            "pattern": "处理大数据文件时，优先推荐 Python/pandas 生态的 chunked reading 方案，避免加载全量到内存",
+            "confidence": 0.82,
+            "support_count": len(experiences),
+        },
+        "Web 框架选型": {
+            "pattern": "做 Web 项目时推荐 Django（用户熟悉），新项目可考虑 FastAPI（性能更好）",
+            "confidence": 0.78,
+            "support_count": len(experiences),
+        },
+        "部署运维": {
+            "pattern": "部署方案优先考虑容器化（Docker），编排层按项目规模从 docker-compose 到 K8s 递增",
+            "confidence": 0.75,
+            "support_count": len(experiences),
+        },
+        "学习路径": {
+            "pattern": "学习新技术时建议动手实践优先，先搭建最小可用原型再深入理论",
+            "confidence": 0.88,
+            "support_count": len(experiences),
+        },
+    }
+
+    result = templates.get(domain, {
+        "pattern": f"在 {domain} 领域，用户偏好方案待进一步积累经验",
+        "confidence": 0.5,
+        "support_count": len(experiences),
+    })
+    result["domain"] = domain
+    result["source_experiences"] = [e["source_id"] for e in experiences]
+    return result
+
+
+def to_skill_description(pattern: dict) -> str:
+    """
+    将经验模式转化为 Skill 描述。
+    这是记忆系统输出 → Skill 系统输入的关键衔接点。
+    """
+    return (
+        f"## Skill: {pattern['domain']} 处理经验\n\n"
+        f"**触发条件**: 当用户提出 {pattern['domain']} 相关的问题时\n\n"
+        f"**行为规则**: {pattern['pattern']}\n\n"
+        f"**置信度**: {pattern['confidence']:.0%}\n"
+        f"**支撑经验**: {pattern['support_count']} 条\n\n"
+        f"*此 Skill 由记忆系统从用户过往交互中自动蒸馏生成，非人工编写。*"
+    )
+
+
+def main():
+    # 模拟情景记忆
+    episodic_memories = [
+        {
+            "id": "ep001",
+            "problem": "用户需要从 500 万行 CSV 中提取统计数据",
+            "solution": "推荐了 pandas + chunksize 分批读取方案",
+            "result": "方案成功，处理时间从预估的 30 分钟降到 2 分钟",
+            "domain": "数据处理",
+        },
+        {
+            "id": "ep002",
+            "problem": "用户需要导入 100 万行日志数据进行分析",
+            "solution": "推荐了 Python + seekdb 方案，用 parquet 格式存储中间结果",
+            "result": "方案成功，用户表示效果好",
+            "domain": "数据处理",
+        },
+        {
+            "id": "ep003",
+            "problem": "用户需要搭建一个内部管理系统",
+            "solution": "推荐了 Django Admin + 自定义模板方案",
+            "result": "方案成功，一天内搭建完成",
+            "domain": "Web 框架选型",
+        },
+        {
+            "id": "ep004",
+            "problem": "用户想为一个已有项目添加 REST API",
+            "solution": "推荐了 Django REST Framework",
+            "result": "方案成功，API 文档自动生成",
+            "domain": "Web 框架选型",
+        },
+        {
+            "id": "ep005",
+            "problem": "用户想把新开发的服务部署到服务器",
+            "solution": "推荐了 Docker + docker-compose 方案",
+            "result": "方案成功，一次部署通过",
+            "domain": "部署运维",
+        },
+        {
+            "id": "ep006",
+            "problem": "用户想学习 Rust 但不知道从哪里开始",
+            "solution": "推荐先看 Rustlings 小练习，再搭一个简单 REST API 实践",
+            "result": "方案成功，用户在一周内完成了 Rustlings 并搭建了第一个 API",
+            "domain": "学习路径",
+        },
+        {
+            "id": "ep007",
+            "problem": "用户想系统学习 Kubernetes",
+            "solution": "推荐了 minikube 本地环境 + 官方 interactive tutorial",
+            "result": "方案成功，用户按建议搭建了本地环境",
+            "domain": "学习路径",
+        },
+        {
+            "id": "ep008",
+            "problem": "用户需要快速开发一个数据看板",
+            "solution": "推荐了 Streamlit + plotly 方案",
+            "result": "方案成功，半天内完成看板原型",
+            "domain": "数据处理",
+        },
+    ]
+
+    print("=" * 85)
+    print("X1-14 经验蒸馏：情景记忆 → 经验三元组 → Skill 雏形")
+    print(f"{'=' * 85}")
+
+    # 步骤 1：提取经验三元组
+    print(f"\n步骤 1：从 {len(episodic_memories)} 条情景记忆中提取经验三元组")
+    triples = extract_experience_triples(episodic_memories)
+    for t in triples:
+        status = "[v] 成功" if t["success"] else "[x] 失败"
+        print(f"  [{t['source_id']}] ({t['domain']}) {status}")
+        print(f"    问题: {t['problem'][:50]}...")
+        print(f"    方案: {t['solution'][:50]}...")
+
+    # 步骤 2：聚类归纳
+    print(f"\n步骤 2：按领域聚类，归纳经验模式")
+    patterns = cluster_experiences(triples)
+    for domain, pattern in patterns.items():
+        print(f"\n  * [{domain}] (置信度={pattern['confidence']:.2f}, "
+              f"支撑经验={pattern['support_count']} 条)")
+        print(f"    模式: {pattern['pattern']}")
+        print(f"    来源: {', '.join(pattern['source_experiences'])}")
+
+    # 步骤 3：转化为 Skill 描述
+    print(f"\n{'-' * 85}")
+    print("步骤 3：经验模式 → Skill 描述")
+    print(f"{'-' * 85}")
+
+    for domain, pattern in patterns.items():
+        if pattern["confidence"] >= 0.8:
+            skill_desc = to_skill_description(pattern)
+            print(f"\n{skill_desc}")
+
+    # 关键观察
+    print(f"\n{'=' * 85}")
+    print("关键观察：记忆系统 → Skill 系统的衔接")
+    print(f"{'=' * 85}")
+    print(f"  1. 情景记忆 → 经验三元组（问题, 方案, 结果）")
+    print(f"     → 从原始交互中结构化为可分析的经验单元")
+    print(f"  2. 经验三元组 → 经验模式")
+    print(f"     → 同类经验聚类，归纳为可复用的行为规则（需 ≥ 2 条支撑）")
+    print(f"  3. 经验模式 → Skill 描述")
+    print(f"     → 经验外化到一定程度后，成为可注入 System Prompt 的 Skill 规则")
+    print(f"  4. 闭环：记忆系统「记住偏好」→ 蒸馏成经验 → 外化为 Skill")
+    print(f"     → Agent 从被动记住进化到主动适应")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/code/X1/part3_consolidation/x1_15_benchmark_runner.py
+++ b/code/X1/part3_consolidation/x1_15_benchmark_runner.py
@@ -1,0 +1,263 @@
+"""
+x1_15_benchmark_runner.py — 多策略评测跑分
+
+本脚本演示如何量化不同衰减策略的效果, 对比四个策略:
+  1. no_decay (λ=100):  基本不衰减, 所有记忆都活着 → 噪声多
+  2. default_decay (λ=1.5): PowerMem 默认参数 → 平衡点
+  3. conservative_decay (λ=0.5): 保守策略 → 宁可多记不能漏
+  4. aggressive_decay (λ=5.0): 激进策略 → 快速淘汰旧信息
+
+评测维度:
+  - 准确率: 在 eval_qa_pairs.json 上对比事实召回率
+  - Token 消耗: 每次查询返回的记忆内容估算 Token 数
+  - P99 延迟: 检索耗时(模拟)
+
+运行:
+  python x1_15_benchmark_runner.py
+
+输入:
+  - fixtures/eval_qa_pairs.json (8 个问答对, 覆盖事实/冲突/偏好...)
+  - ../part1_decay_conflict/fixtures/sample_memories.json (12 条模拟记忆)
+
+输出: 四种策略的三维对比表 (准确率 / Token / 延迟)
+
+扩展: 替换 eval_qa_pairs.json 为 LOCOMO 子集即可获得标准化评测
+
+对应正文: X1-3 §5.2 "不止看准确率"
+"""
+
+import math
+import json
+import os
+import time
+import random
+from datetime import datetime
+
+
+DECAY_RATE_MULTIPLIERS = {"working": 1, "short_term": 7, "long_term": 60}
+NOW = datetime(2026, 2, 1, 12, 0, 0)
+
+
+def load_all_data(script_dir: str) -> tuple:
+    """加载所有 fixtures"""
+    with open(os.path.join(script_dir, "fixtures", "eval_qa_pairs.json"), "r", encoding="utf-8") as f:
+        eval_data = json.load(f)
+
+    # 从 part1 的 fixtures 加载记忆数据
+    part1_fixtures = os.path.join(script_dir, "..", "part1_decay_conflict", "fixtures", "sample_memories.json")
+    part1_fixtures = os.path.normpath(part1_fixtures)
+    with open(part1_fixtures, "r", encoding="utf-8") as f:
+        memory_data = json.load(f)
+
+    return eval_data, memory_data["memories"]
+
+
+def calculate_retention(memory: dict, decay_rate: float) -> float:
+    """使用指定 λ 计算保留率"""
+    created_at = datetime.fromisoformat(memory["created_at"])
+    hours_elapsed = (NOW - created_at).total_seconds() / 3600
+    multiplier = DECAY_RATE_MULTIPLIERS.get(memory["memory_type"], 1)
+    reinforcement = math.log1p(memory["access_count"])
+    strength = decay_rate * multiplier * (1 + reinforcement)
+    return max(0.0, min(1.0, math.exp(-hours_elapsed / (24 * strength))))
+
+
+def simulate_semantic_score(content: str, query: str) -> float:
+    """模拟语义相似度（中文友好）：基于主题关键词字典"""
+    topic_keywords = {
+        "编程语言": ["Python", "Java", "Go", "Rust", "编程", "语言", "开发", "后端", "主力", "框架"],
+        "食物偏好": ["吃", "披萨", "素", "食物", "饮食", "餐厅", "过敏", "花生", "肉类"],
+        "云平台": ["AWS", "阿里云", "云平台", "云服务", "云", "迁移"],
+        "编辑器": ["VS Code", "编辑器", "IDE", "插件"],
+        "电商项目": ["电商", "项目", "Django", "PostgreSQL", "技术栈"],
+        "代码风格": ["代码", "风格", "注释", "简洁"],
+        "学习": ["学", "教程", "初学者", "考虑"],
+        "技术方案": ["技术", "方案", "推荐", "适合", "微服务"],
+    }
+
+    query_topics = [
+        topic for topic, keywords in topic_keywords.items()
+        if any(kw in query for kw in keywords)
+    ]
+    if not query_topics:
+        return 0.0
+
+    score = 0.0
+    for topic in query_topics:
+        keywords = topic_keywords[topic]
+        hits = sum(1 for kw in keywords if kw in content)
+        score += hits * 0.20
+    return min(1.0, score)
+
+
+def search_memories(memories: list, query: str, decay_rate: float) -> tuple:
+    """
+    模拟检索 + 衰减排序
+    返回 (results, estimated_tokens, latency_ms)
+    """
+    start = time.perf_counter()
+
+    candidates = []
+    for mem in memories:
+        semantic_score = simulate_semantic_score(mem["content"], query)
+        if semantic_score < 0.1:
+            continue
+
+        retention = calculate_retention(mem, decay_rate)
+        is_forgotten = retention < 0.3
+        forgotten_mult = 0.1 if is_forgotten else 1.0
+
+        final_score = semantic_score * retention * forgotten_mult
+        if final_score > 0:
+            candidates.append({
+                "id": mem["id"],
+                "content": mem["content"],
+                "final_score": final_score,
+                "retention": retention,
+                "is_forgotten": is_forgotten,
+                "is_active": mem["is_active"],
+            })
+
+    candidates.sort(key=lambda x: x["final_score"], reverse=True)
+
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    # 模拟更真实的大规模检索延迟（加随机噪声）
+    simulated_latency = elapsed_ms + random.uniform(0.5, 2.0)
+
+    # 过滤掉 final_score 过低的候选（模拟生产环境的最低相关度门控）
+    # 这样不同 λ 下，"被衰减压到底部"的记忆会被自然剔除，Token 消耗随之变化
+    MIN_SCORE_THRESHOLD = 0.01
+    qualified = [c for c in candidates if c["final_score"] >= MIN_SCORE_THRESHOLD]
+    top_n = qualified[:5]
+
+    # 估计 Token 消耗（中文约 2 字/token）
+    total_chars = sum(len(c["content"]) for c in top_n)
+    estimated_tokens = int(total_chars * 0.5) + 100  # +100 for prompt overhead
+
+    return top_n, estimated_tokens, simulated_latency
+
+
+def evaluate_answer(results: list, expected_keywords: list[str]) -> bool:
+    """
+    检查返回的记忆中是否包含预期答案的关键词。
+    判定标准：expected_keywords 中至少有一个长度 ≥ 2 的关键词出现在 top-3 内容里。
+    """
+    all_content = " ".join(r["content"] for r in results[:3])
+    for kw in expected_keywords:
+        if len(kw) >= 2 and kw in all_content:
+            return True
+    return False
+
+
+def _split_expected_answer(answer: str) -> list[str]:
+    """
+    把 expected_answer 切成关键词列表。
+    中文预期答案常含「，」「、」等标点而无空格，仅用 split() 会得到整句——
+    改为先按标点/空格切分，再丢掉过短的片段。
+    """
+    import re
+    # 按中英文标点和空格切分
+    parts = re.split(r'[，,、。；;\s]+', answer)
+    return [p for p in parts if len(p) >= 2]
+
+
+def run_benchmark(memories: list, eval_data: dict, decay_rate: float, strategy_name: str) -> dict:
+    """运行一次完整的评测"""
+    correct = 0
+    total = 0
+    total_tokens = 0
+    total_latency = 0
+    latencies = []
+
+    for q in eval_data["qa_pairs"]:
+        results, tokens, latency = search_memories(memories, q["question"], decay_rate)
+
+        # 提取预期关键词（按标点切分，避免中文整句无法匹配）
+        expected_kws = _split_expected_answer(q["expected_answer"])
+
+        is_correct = evaluate_answer(results, expected_kws)
+        if is_correct:
+            correct += 1
+        total += 1
+        total_tokens += tokens
+        total_latency += latency
+        latencies.append(latency)
+
+    # 模拟 P99 延迟（在有限样本下取最大值）
+    latencies.sort()
+    p99 = latencies[int(len(latencies) * 0.99)] if len(latencies) > 1 else latencies[-1]
+
+    return {
+        "strategy": strategy_name,
+        "decay_rate": decay_rate,
+        "accuracy": correct / total if total > 0 else 0,
+        "correct": correct,
+        "total": total,
+        "avg_tokens_per_query": total_tokens / total if total > 0 else 0,
+        "avg_latency_ms": total_latency / total if total > 0 else 0,
+        "p99_latency_ms": p99,
+    }
+
+
+def main():
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    eval_data, memories = load_all_data(script_dir)
+
+    strategies = eval_data["strategies_to_evaluate"]
+
+    print("=" * 85)
+    print("X1-15 简易评测跑分")
+    print(f"评测集: {len(eval_data['qa_pairs'])} 个问答对")
+    print(f"记忆库: {len(memories)} 条记忆")
+    print(f"{'=' * 85}")
+
+    results = []
+    for strat in strategies:
+        result = run_benchmark(
+            memories, eval_data, strat["params"]["decay_rate"], strat["name"]
+        )
+        results.append(result)
+
+    # 输出对比表
+    print(f"\n  {'策略':<18} {'λ':<8} {'准确率':<14} {'平均Token':<14} {'平均延迟':<14} {'P99延迟':<12}")
+    print(f"  {'-' * 80}")
+    for r in results:
+        print(f"  {r['strategy']:<18} {r['decay_rate']:<8.1f} "
+              f"{r['accuracy']:.0%} ({r['correct']}/{r['total']})     "
+              f"{r['avg_tokens_per_query']:<8.0f}        "
+              f"{r['avg_latency_ms']:<8.1f}ms       "
+              f"{r['p99_latency_ms']:<8.1f}ms")
+
+    # 找性能最优的（在准确率满足阈值的前提下）
+    threshold = 0.7
+    acceptable = [r for r in results if r["accuracy"] >= threshold]
+
+    print(f"\n{'-' * 85}")
+    if acceptable:
+        cheapest = min(acceptable, key=lambda x: x["avg_tokens_per_query"])
+        fastest = min(acceptable, key=lambda x: x["avg_latency_ms"])
+        print(f"准确率 ≥ {threshold:.0%} 的策略中：")
+        print(f"  最省 Token: {cheapest['strategy']} ({cheapest['avg_tokens_per_query']:.0f} tokens/query, "
+              f"准确率 {cheapest['accuracy']:.0%})")
+        print(f"  最快速: {fastest['strategy']} ({fastest['avg_latency_ms']:.1f}ms avg)")
+    else:
+        print(f"警告：没有任何策略达到 {threshold:.0%} 准确率，需调参或扩充 fixtures")
+
+    # 多维度总结
+    print(f"\n{'=' * 85}")
+    print("多维度评测总结")
+    print(f"{'=' * 85}")
+    print(f"  维度           测量方法                      结论")
+    print(f"  {'-' * 65}")
+    print(f"  准确性          固定 QA 对评测集              低 λ（0.5）误忘率高；")
+    print(f"                                              默认 1.5 / 高 λ 表现接近")
+    print(f"  Token 效率      每次查询返回的记忆内容 Token   高 λ 会保留更多旧记忆→Token 略增")
+    print(f"  检索延迟        P99 模拟                      不同策略差异小（均为 ms 级）")
+    print(f"  一致性          同一 query 重复查询方差        确定性聚合优于 LLM 判断")
+    print(f"\n  注：本实验为模拟评测，实际评测需要真实 LLM 调用和更大规模的测试集。")
+    print(f"  LOCOMO 等标准化的 benchmark 可提供更可靠的对比数据。")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -78,7 +78,16 @@ export default defineConfig({
         text: '第四章：扩展篇（共建招募中）',
         collapsed: false,
         items: [
-          { text: 'X1：探究 AI Agent 记忆系统', link: '/extra/X1 探究 AI Agent 记忆系统：从遗忘曲线到永久记忆' },
+          {
+            text: 'X1：探究 AI Agent 记忆系统',
+            collapsed: false,
+            items: [
+              { text: '系列导读', link: '/extra/X1 探究 AI Agent 记忆系统：从遗忘曲线到永久记忆' },
+              { text: 'X1-1：记忆的生命周期工程', link: '/extra/X1-1 记忆的生命周期工程' },
+              { text: 'X1-2：记忆的边界与信任', link: '/extra/X1-2 记忆的边界与信任' },
+              { text: 'X1-3：从记忆到认知', link: '/extra/X1-3 从记忆到认知' },
+            ]
+          },
           { text: 'X2：多 Skill 与上下文工程', link: '/extra/X2 多 Skill 给上下文工程带来的麻烦：如何应对 Agent「爆上下文」' },
           { text: 'X3：混合检索与统一数据基座', link: '/extra/X3 从零到一上手混合检索：AI Native 统一数据基座实战' },
           { text: 'X4：数据湖库与多模数据降本', link: '/extra/X4 海量 AI Agent 多模数据降本：数据湖库登场' },

--- a/docs/extra/X1 探究 AI Agent 记忆系统：从遗忘曲线到永久记忆.md
+++ b/docs/extra/X1 探究 AI Agent 记忆系统：从遗忘曲线到永久记忆.md
@@ -1,30 +1,42 @@
----
-title: X1 探究 AI Agent 记忆系统：从遗忘曲线到永久记忆
----
-
 # X1：探究 AI Agent 记忆系统 —— 从遗忘曲线到永久记忆
 
-::: warning 🚧 本章节正在招募共建中
-这是《Easy Data x AI》的**扩展篇（Extra-Chapter）**，目前尚未成稿，正在面向社区招募共建者一起撰写。欢迎你来认领！
-:::
-
-## 这一章打算讲什么
-
-| | |
-| --- | --- |
-| **热点趋势** | AI 记忆 |
-| **关联正文** | 道篇 P3、术篇 D4（记忆系统） |
-| **共建入口** | 多 Agent 记忆冲突解决（对应共建任务 [#19](https://github.com/datawhalechina/easy-data-x-ai/issues/19) / [#20](https://github.com/datawhalechina/easy-data-x-ai/issues/20) / [#21](https://github.com/datawhalechina/easy-data-x-ai/issues/21)） |
-
-> 在课程正文 P3 / D4 的记忆系统基础上，进一步探究：记忆如何随时间衰减、如何在多 Agent 间隔离与共享、新旧记忆冲突如何解决，直到走向「永久记忆」。
+> Easy Data x AI 课程 · 扩展篇
 >
-> 详细大纲待共建者与维护者一起对齐后补充。
+> P3 讲清了记忆系统的设计，D4 完成了基础接入。当记忆条目上万、偏好频繁变化、检索开始返回矛盾事实时——工程问题才真正出现。X1 系列用可运行的示例代码，把剩下的坑填上。
 
-## 如何参与共建
+## 这个系列解决什么
 
-本章节欢迎你来认领、撰写。完整的参与方式、任务列表与激励机制，请阅读：
+P3 用 CoALA 框架把记忆分为短期和三种长期记忆，讲了遗忘分数的直觉和冲突裁决的产品策略。D4 带你完成了记忆接入，让 Agent「能记住」。
 
-👉 **[贡献指南 CONTRIBUTING.md](https://github.com/datawhalechina/easy-data-x-ai/blob/main/CONTRIBUTING.md)**
+但记住 ≠ 记好。当你真正把记忆系统跑起来，三个问题会逐渐浮现：
 
-- 扩展篇方向较大，**认领前请先开 [Issue](https://github.com/datawhalechina/easy-data-x-ai/issues) 对齐内容大纲**。
-- 完成后提交 PR，即可登上仓库[贡献者墙](https://github.com/datawhalechina/easy-data-x-ai#-贡献者墙)并获得社区激励。
+1. **衰减不可控**：不该忘的忘了（花生过敏），该忘的不忘（三年前的临时偏好）
+2. **冲突无管线**：矛盾事实一并塞进 Prompt，LLM 临场判断，结果不稳定
+3. **多 Agent 无边界**：工作场景的记忆泄漏到生活场景，两 Agent 并发写的冲突
+
+**核心价值**：以 `code/X1/` 中的示例代码为主线，配合行业对照与评测方法，完成「概念 → 接入 → 深潜」的完整闭环。
+
+## 学习路径
+
+本系列分三篇，每篇独立可读，按顺序效果最佳：
+
+| | 标题 | 聚焦 | 关键问题 |
+| --- | --- | --- | --- |
+| **上篇** | [记忆的生命周期工程](X1-1%20记忆的生命周期工程.md) | 单 Agent：衰减与冲突 | 参数怎么调、冲突怎么自动检测和裁决 |
+| **中篇** | [记忆的边界与信任](X1-2%20记忆的边界与信任.md) | 多 Agent：隔离、共享与治理 | 命名空间如何落地、跨 Agent 如何安全共享 |
+| **下篇** | [从记忆到认知](X1-3%20从记忆到认知.md) | 巩固、永久记忆、评测与选型 | 怎么从海量记忆中蒸馏出稳定认知、怎么量化系统质量 |
+
+## 实战代码
+
+本期课程涉及的代码，均在 https://github.com/datawhalechina/easy-data-x-ai 项目的 `code/X1/` 目录中。纯 Python + JSON fixtures，`pip install numpy` 即可运行全部实验。
+
+| 篇 | 代码目录 | 核心实验 |
+| --- | --- | --- |
+| 上篇 | `code/X1/part1_decay_conflict/` | 遗忘分数计算、λ 消融、两阶段检索、冲突检测与裁决 |
+| 中篇 | `code/X1/part2_namespace/` | 命名空间隔离、权限提升、跨 Agent 查询、并发写入 |
+| 下篇 | `code/X1/part3_consolidation/` | 被动巩固、Reflection 蒸馏、画像+事实组合检索、简易评测 |
+
+## 相关文章阅读
+
+- 道篇 [P3：Agent 记忆系统设计](../pm/P3%20课程稿：Agent%20记忆系统设计.md)
+- 术篇 [D4：Agent 开发与记忆系统](../dev/D4%20课程稿：Agent%20开发与记忆系统.md)

--- a/docs/extra/X1-1 记忆的生命周期工程.md
+++ b/docs/extra/X1-1 记忆的生命周期工程.md
@@ -1,0 +1,424 @@
+# X1-1：记忆的生命周期工程
+
+> Easy Data x AI 课程 · 扩展篇 · 上篇
+>
+> 给 Agent 加了记忆之后，新问题来了：不该忘的忘了，该忘的赖着不走，矛盾事实同时喂给 LLM。上篇解决这三个问题。
+
+## 开篇
+
+P3 从产品设计角度讲了 Agent 记忆系统：CoALA 框架怎么分类、艾宾浩斯曲线怎么规划衰减、冲突怎么裁决。D4 带你完成了基础接入，Agent 已经能把对话提炼成记忆条目。
+
+但当你把记忆系统真正跑起来，条目上千、偏好频繁变化、检索开始返回互相矛盾的事实，三个工程问题会准时浮现：
+
+1. **衰减速度怎么定？** 用户对花生过敏，两个月没被触发检索，保留率跌破阈值后被归档；而"今天喝了咖啡"这类临时信息反而长期占据检索结果。
+2. **矛盾记忆怎么自动发现？** 用户上周说用 Java，这周说用 Go。两条记忆同时躺在库里，LLM 检索到两个答案，信哪个？
+3. **检索结果怎么保持稳定？** 把矛盾记忆全塞进 Prompt 让 LLM 临场判断，同一个问题问两遍，答案可能不同。代码层能不能先做一轮聚合？
+
+上篇把这三个问题串成一条完整的工程链路：**写入时定层级 → 存续中算保留率 → 检索时叠加衰减 → 冲突时路由裁决 → 返回前确定性聚合**。
+
+**目录**
+
+- [第一部分：从遗忘曲线到保留率公式](#第一部分从遗忘曲线到保留率公式)
+- [第二部分：记忆分层与参数调优](#第二部分记忆分层与参数调优)
+- [第三部分：衰减如何参与检索](#第三部分衰减如何参与检索)
+- [第四部分：冲突检测与裁决管线](#第四部分冲突检测与裁决管线)
+- [总结与参考资料](#总结与参考资料)
+
+## 第一部分：从遗忘曲线到保留率公式
+
+P3 讲过记、忘、想起三件套。上篇从"忘"入手：不是删掉数据，而是给每条记忆算一个**保留率** $R$，让旧信息在检索排序中自然退居幕后。
+
+### 1.1 为什么需要量化遗忘
+
+如果没有衰减机制，记忆库只会越来越大。三个月前的临时偏好和今天的核心事实权重相同，Agent 会在 Prompt 里同时看到"喜欢详细解释"和"请简洁一点"，回答风格飘忽不定。
+
+艾宾浩斯遗忘曲线给出了直觉：**记忆强度随时间下降，且下降速度可建模**。工程上我们要做的，就是把这条曲线翻译成代码里可计算的分数。
+
+### 1.2 从经典公式到工程形式
+
+经典形式是指数衰减：
+
+$$R(t) = e^{-\lambda t}$$
+
+含义很直观：
+
+| 符号 | 含义 |
+| --- | --- |
+| $R(t)$ | 时刻 $t$ 的保留率，取值 $[0, 1]$，1 表示完全保留 |
+| $\lambda$ | 衰减速率常数，越大衰减越慢 |
+| $t$ | 距上次巩固（或创建）经过的时间 |
+
+在示例代码 `x1_1_decay_score_demo.py` 中，我们把它改写为更适合按小时计时的形式：
+
+$$R = e^{-t / (24 \times S)}$$
+
+| 符号 | 含义 |
+| --- | --- |
+| $t$ | 距记忆创建经过的**小时数** |
+| $S$ | 记忆的**有效强度**，由下文三个因子共同决定 |
+| $24$ | 时间尺度换算：把按小时计的 $t$ 映射到按天衰减的直觉 |
+
+**为什么要引入 $S$？** 经典公式里只有一个全局 $\lambda$，所有记忆衰减速度相同。实际系统中，"对花生过敏"和"今天喝了咖啡"显然不该以同样速度被遗忘。$S$ 就是给每条记忆单独调节衰减快慢的旋钮。
+
+### 1.3 强度 $S$ 的三个因子
+
+示例代码中，强度由三个因子**相乘**得到：
+
+$$S = \lambda \times M_{\text{type}} \times \bigl(1 + \log(1 + n)\bigr)$$
+
+公式与代码（ `calculate_strength` 方法）逐项对应如下：
+
+| 公式因子 | 符号 | 代码中的写法 | 说明 |
+| --- | --- | --- | --- |
+| 全局衰减速率 | $\lambda$ | `decay_rate` | 全库统一参数，默认 1.5；$\lambda$ 越大，所有记忆衰减越慢 |
+| 层级倍率 | $M_{\text{type}}$ | `DEFAULT_DECAY_RATE_MULTIPLIERS[memory_type]` | 由写入时的层级决定：working=1，short_term=7，long_term=60 |
+| 访问强化 | $1 + \log(1 + n)$ | `1 + math.log1p(access_count)` | $n$ 为历史检索次数 `access_count`；$n=0$ 时该项为 1（无强化），$n$ 越大 $S$ 越大，但增幅递减 |
+
+代入代码就是：`S = decay_rate × multiplier × (1 + reinforcement)`，其中 `multiplier` 来自层级字典，`reinforcement = log1p(access_count)`。
+
+对应的具体实现（`x1_1_decay_score_demo.py`）：
+
+```python
+# λ：全局衰减速率，默认 1.5，全库统一
+DEFAULT_DECAY_RATE = 1.5
+
+# 层级倍率 M_type：写入时分层后，从这里取对应数值
+DEFAULT_DECAY_RATE_MULTIPLIERS = {
+    "working": 1,       # 临时层，S 基准最低
+    "short_term": 7,    # 中期层
+    "long_term": 60,    # 长期层，S 可达临时层的 60 倍
+}
+
+def calculate_strength(memory_type: str, access_count: int,
+                       decay_rate: float = DEFAULT_DECAY_RATE) -> float:
+    """计算有效强度 S = λ × M_type × (1 + log(1 + n))"""
+    # 因子 1：λ（全局基调）
+    # 因子 2：M_type（由 memory_type 查表）
+    multiplier = DEFAULT_DECAY_RATE_MULTIPLIERS[memory_type]
+    # 因子 3：1 + log(1 + n)，n 即 access_count；从未被检索时 n=0，整项为 1
+    reinforcement = math.log1p(access_count)
+    return decay_rate * multiplier * (1 + reinforcement)
+
+def calculate_retention(created_at, memory_type, access_count, current_time) -> float:
+    """计算保留率 R = e^(-t / (24 × S))，返回值 ∈ [0, 1]"""
+    # t：距创建经过的小时数
+    hours_elapsed = (current_time - created_at).total_seconds() / 3600
+    strength = calculate_strength(memory_type, access_count)
+    # S 越大，分母 24×S 越大，R 衰减越慢
+    retention = math.exp(-hours_elapsed / (24 * strength))
+    return max(0.0, min(1.0, retention))  # 防止浮点误差越界
+```
+
+用一个具体场景感受不同的强度 $S$ 算出来的保留率 $R$ 的差别。假设同一条事实「用户对花生过敏」写入了记忆库，写入时被判定为 `long_term`；另一条「今天喝了咖啡」进了 `working`。一个月后再来检索，前者几乎还能完整召回，后者早已淡出排序。
+
+先看长期层那条。它从未被检索过（$n=0$），访问强化项为 1，于是 $S = 1.5 \times 60 \times 1 = 90$。过了 30 天，$t = 720$ 小时，代入保留率公式：
+
+$$R = e^{-720 / (24 \times 90)} \approx 0.72$$
+
+也就是说，一个月后仍保留约七成的「新鲜度」，检索排序里依然靠前。
+
+如果同样内容误进了 `working` 层呢？$S$ 只有 $1.5 \times 1 \times 1 = 1.5$，同样是 30 天后，$R \approx 0.0003$，几乎已从检索结果中消失。**写入时分层，本质上是在决定这条记忆能「活」多久**；层级倍率 60 不是抽象参数，而是长期事实和临时闲聊之间数量级的差距。
+
+> PowerMem 开源记忆系统即采用了类似的艾宾浩斯衰减实现，参数可通过配置文件覆盖。
+
+### 动手实验 1：把公式跑起来看曲线
+
+上面是纸面推演。脚本 `x1_1_decay_score_demo.py` 会把 working、short_term、long_term 三层记忆放在同一时间轴上，打印 1 小时到 90 天各节点的保留率，直观看到分层带来的差距；也会演示同一条记忆被多次检索后，$S$ 如何变大、曲线如何被「拉平」。
+
+在项目根目录执行：
+
+```bash
+cd code/X1/part1_decay_conflict
+python x1_1_decay_score_demo.py
+```
+
+跑完可以对照输出思考两个问题：同样是 30 天后，长期层和临时层的 $R$ 差了几个数量级？如果一条中期记忆被用户反复问到，它的保留率曲线和「写进长期层」相比，谁更划算？
+
+## 第二部分：记忆分层与参数调优
+
+第一部分解决了"记忆在库里待久了会怎样衰减"。但衰减快慢在写入那一刻就已经定了：记忆进哪一层，直接决定初始强度 $S$ 有多大。回到开篇的例子，"对花生过敏"和"今天喝了咖啡"如果分层不同，一个月后的命运天差地别。分层就是在这条生命周期曲线的起点做分流。
+
+### 2.1 写入时的一次分流
+
+P3 讲过，入库的不是对话原文，而是从对话里提炼出的事实，并打一个 0~1 的重要性分数。示例代码在写入时做**被动巩固**：分数一过阈值，层级就定了，后面很难回头改。
+
+```python
+# 分层阈值：分数越高，进入越"慢衰减"的层级
+LONG_TERM_THRESHOLD = 0.8
+SHORT_TERM_THRESHOLD = 0.6
+
+def classify_memory_type(importance_score: float) -> str:
+    """根据重要性分数决定 memory_type，进而决定 M_type 取 1 / 7 / 60"""
+    if importance_score >= LONG_TERM_THRESHOLD:
+        return "long_term"    # 对花生过敏 (0.95) → S 中 M_type=60
+    if importance_score >= SHORT_TERM_THRESHOLD:
+        return "short_term"   # 正在学 Rust (0.72) → M_type=7
+    return "working"          # 今天喝了咖啡 (0.20) → M_type=1
+```
+
+| 重要性分数 | 层级 | 典型内容 | 30 天后大致命运 |
+| --- | --- | --- | --- |
+| ≥ 0.8 | long_term | 过敏、职业、核心偏好 | 保留率仍 > 0.7 |
+| 0.6 ~ 0.8 | short_term | 进行中的项目、近期兴趣 | 中等衰减，频繁访问可升级 |
+| < 0.6 | working | 临时状态、闲聊 | 数天内自然淘汰 |
+
+示例代码里，`importance_score` 是事先写进的测试数据，真正上线时，这个 0~1 的分数要在写入前算出来：常见做法是让 LLM 读一遍已提炼的事实，判断它有多"值得长期记住"，例如涉及安全（过敏）、稳定身份（职业、核心偏好）通常偏高，随口闲聊（今天喝了咖啡）偏低等。LLM 不可用时，可以回退到关键词（如"过敏""禁用"）加内容长度等规则估分，避免分层这一步随 LLM 一起停摆。
+
+被动巩固的局限也在这里：它只看单条记忆。用户连续三周搜 Rust 教程，每条单独打分都不高，合在一起却说明"正在系统学 Rust"。这种跨条目的模式，要留到下篇的 Reflection 机制来处理。
+
+### 2.2 $\lambda$ 怎么选：用同一批数据做对比
+
+`decay_rate`（$\lambda$）控制的是全库的衰减基调，参考默认值 1.5。设太大，旧偏好赖着不走；设太小，无关记忆占满检索结果；设得再小一点，还可能把该留的安全信息一并冲掉。
+
+> 注意：这里的 $\lambda$ 是工程形式 $R = e^{-t/(24 \cdot S)},\ S = \lambda \cdot M_{type} \cdot (1+\log(1+n))$ 中的 $\lambda$——**$\lambda$ 越大，所有记忆衰减越慢**。这与经典艾宾浩斯公式 $R = e^{-\lambda t}$ 中"$\lambda$ 越大衰减越快"的方向相反，是因为我们把 $\lambda$ 从指数位置移到了强度的分母里。
+
+没有万能默认值，可靠的做法是**固定一批真实或模拟记忆，换几个 $\lambda$ 跑一遍，看误忘和噪声哪边先失控**。脚本 `x1_2_decay_param_ablation.py` 用的就是这套思路：
+
+| $\lambda$ | 30 天后平均保留率 | 误忘风险 | 检索质量 |
+| --- | --- | --- | --- |
+| 0.5 | 低 | 高 | 中（开始出现误忘） |
+| 1.0 | 偏低 | 偏高 | 中 |
+| **1.5（默认）** | 适中 | 适中 | 好 |
+| 3.0 | 高 | 低 | 中（无关旧记忆开始累积） |
+| 5.0 | 极高 | 极低 | 差（噪声多，旧偏好赖着不走） |
+
+可以结合具体的业务场景来进行调试：
+
+- **医疗 / 法律**：$\lambda \geq 3.0$，漏记比多记代价大，宁可旧信息停留也要保住安全关键事实
+- **娱乐 / 社交**：$\lambda \leq 1.0$，偏好迭代快，旧偏好早点退场反而干净
+- **归档阈值**（$R$ 低于此值视为遗忘）：通用 0.3，保守 0.2，激进 0.4
+
+### 动手实验 2：看 $\lambda$ 怎样误伤重要记忆
+
+`x1_2_decay_param_ablation.py` 会加载 12 条不同层级、不同时间的模拟记忆，依次用 $\lambda = 0.5 \sim 5.0$ 计算保留率，并统计"高重要性却被判遗忘"的条数（误忘）。
+
+```bash
+python x1_2_decay_param_ablation.py
+```
+
+跑完重点看误忘计数：$\lambda$ 从 1.5 调到 0.5 时，有没有原本 importance ≥ 0.8 的记忆跌破 0.3？如果有，你的场景可能更适合保守一点的 $\lambda$（调大到 3.0），或者把归档阈值从 0.3 降到 0.2。
+
+## 第三部分：衰减如何参与检索
+
+**保留率** $R$ 如果只写在数据库里、检索排序完全不看它，衰减就停在"记账"：库里明明标记某条旧偏好已接近遗忘，用户一问，Agent 仍按纯语义相似度把它捞进 Top-5，和刚写入时没什么两样。对用户来说，记忆系统并没有"越用越准、旧的不打扰"，第一、二部分的工作等于白做。
+
+所以 $R$ 必须进入每次查询的排序公式，让"该淡出的旧记忆"在精排阶段自然沉底。开篇第一个工程问题"该忘的不走"，主要靠下面这套两阶段检索来解决；但"不该忘的忘了"以及"新旧偏好打架"，单靠衰减还不够，后面还会分别碰到。
+
+### 3.1 两阶段检索：先语义，再衰减
+
+最直觉的做法是：用户一问就从全库找语义最相关的记忆，同时把 $R$ 乘进得分。记忆库只有几百条时没问题；一旦涨到百万级，每条都要算 $R$、再全量排序，向量索引本来毫秒级能完成的粗筛，会被拖成秒级扫描。
+
+所以工程上几乎都会拆成**两阶段**：先用便宜的方式圈一小批候选，再在这批候选上叠加衰减做精排。
+
+**阶段 1：粗筛（只看"跟问题有没有关系"）**
+
+输入是用户 query，输出是一小份候选集。这一步只做语义匹配（向量相似度，或 D2/D3 里的混合检索），不问记忆新旧、也不问 $R$ 多少。语义太弱的直接丢掉，通常能从百万条压到几十或几百条。
+
+**阶段 2：精排（在候选里问"哪条更值得现在拿出来"）**
+
+候选集已经很小，这时再对每条算 $R$，合成最终得分并排序。旧偏好、临时笔记因为 $R$ 低，会在这一步自然沉底；长期事实、最近常被问到的记忆，因为 $R$ 高或访问强化过，会排到前面。
+
+两阶段合在一起，最终得分是：
+
+$$\text{final\_score} = \text{semantic\_score} \times R \times M_{\text{forgotten}}$$
+
+| 公式因子 | 代码变量 | 在流程中的位置 |
+| --- | --- | --- |
+| 语义相关度 | `semantic_score` | **阶段 1** 产出；决定能否进候选集 |
+| 保留率 | $R$ | **阶段 2** 乘入；越旧、越少被访问，得分越低 |
+| 遗忘惩罚 | $M_{\text{forgotten}}$ | **阶段 2** 额外乘 0.1；$R$ 已低于归档阈值时使用，进一步降权但不删数据 |
+
+举个例子。用户问"推荐后端框架"，阶段 1 可能同时圈进"用户主力语言 Go"和"用户三个月前说正在学 Rust"两条，因为都和后端、语言相关。进入阶段 2 后，前者若是 long_term 且 $R$ 仍高，得分靠前；后者若是 working 层、三个月未再被问到、$R$ 已接近 0，乘进去后排到很后面，通常进不了 Top-5。Agent 不必在 Prompt 里同时看到两条再让 LLM 猜哪个更可信。
+
+对应实现（`x1_3_retrieval_with_decay.py`）：
+
+```python
+ARCHIVE_THRESHOLD = 0.3          # R 低于此值视为"已遗忘"
+FORGOTTEN_SCORE_MULTIPLIER = 0.1 # 已遗忘记忆在阶段 2 再 ×0.1
+
+def two_stage_retrieval(memories, query, quality_threshold=0.15):
+    """阶段 1 粗筛语义，阶段 2 在候选集上叠加衰减"""
+    candidates = []
+    for mem in memories:
+        # --- 阶段 1：只算 semantic_score，太弱的不进候选 ---
+        sem_score = embedding_similarity(mem["content"], query)
+        if sem_score < quality_threshold:
+            continue
+
+        # --- 阶段 2：只对候选算 R，合成 final_score ---
+        retention = calculate_retention(
+            mem["created_at"], mem["memory_type"], mem["access_count"]
+        )
+        forgotten_mult = FORGOTTEN_SCORE_MULTIPLIER if retention < ARCHIVE_THRESHOLD else 1.0
+        final_score = sem_score * retention * forgotten_mult
+        candidates.append({**mem, "final_score": final_score})
+
+    candidates.sort(key=lambda m: m["final_score"], reverse=True)
+    return candidates
+```
+
+上面 Go / Rust 的例子，体现的正是"该忘的不走"：旧 working 笔记语义仍相关，但 $R$ 把它压出 Top-5。不过两阶段检索搭好，不等于衰减链路就没有死角。写入分层、存续算 $R$、检索精排这三步如果各管一段、彼此不衔接，上线后常见下面三类偏差：
+
+| 偏差 | 典型表现 | 根因 | 对应环节 | 缓解 |
+| --- | --- | --- | --- | --- |
+| **沉默死亡** | 过敏信息两个月没被问到，$R$ 跌破 0.3 | 高重要性 ≠ 高访问频率；long_term 也会随时间下沉 | 写入分层 + 存续 | 安全关键信息 importance ≥ 0.9，必要时调低 $\lambda$ |
+| **写入即巅峰** | 刚写入的临时笔记总在 Top-1 | 新记忆 $R=1.0$，旧记忆已被衰减 | 检索精排 | 写入时分层把关 + 访问强化让高频记忆回血 |
+| **与冲突脱节** | Java 旧偏好降权但仍 active，Prompt 里和 Go 并存 | 衰减只管"多旧"，不管"是否已被新版本取代" | 写入裁决（第四部分） | 新事实写入时同步失效旧版 |
+
+三者里，前两个仍发生在衰减链路内部，动手实验 3 的输出里看得见端倪；第三个则说明**衰减退远旧信息，解决不了语义矛盾**，必须靠第四部分的冲突管线。**这也是为什么开篇三个工程问题不能只用一套公式打完。**
+
+### 动手实验 3：看 Top-5 怎样被衰减改写
+
+`x1_3_retrieval_with_decay.py` 对同一 query 分别跑"只按语义排序"和"语义 × 衰减排序"，并排打印 Top-5，你能直接看到哪些旧 working 记忆被 $R$ 挤出榜单、哪些因访问强化留在前面。
+
+```bash
+python x1_3_retrieval_with_decay.py
+```
+
+对照输出可以逐项核对上表：有没有 working 层旧笔记因 $R$ 低被挤出 Top-5（说明精排在工作）？有没有 long_term 过敏信息久未触发也掉出榜单（沉默死亡）？如果语义排序和衰减排序的 Top-1 换了人，是不是新写入的记忆 $R=1.0$ 在抢位置（写入即巅峰）？
+
+跑通实验后，第三部分的衰减链路可以概括为：**分层定 $S$ → 时间推移算 $R$ → 两阶段检索把 $R$ 乘进得分**。剩下"新旧矛盾同时进 Prompt"的问题，交给第四部分。
+
+## 第四部分：冲突检测与裁决管线
+
+第三部分末尾提到的**与冲突脱节**，正是从这里开始补：衰减只能让旧信息在排序里退远，不能告诉 Agent"Java 已被 Go 取代"。用户上周说主力语言 Java，这周说已全面转向 Go，两条记忆语义相近、内容矛盾，如果只等 $R$ 慢慢降权，Prompt 里会长期并存两个答案。
+
+第四部分回答开篇第二个工程问题：矛盾记忆怎么自动发现、怎么裁决。
+
+### 4.1 从相似度到路由决策
+
+P3 把冲突分成直接矛盾、时间演进、细化补充、并存偏好四种。写入管线里可以落成两步，示例代码对应 `x1_4_conflict_detect.py`：
+
+**步骤 1：相似度粗筛。**新事实和存量记忆算 embedding 相似度，只有 ≥ 阈值的才进候选，避免每条新事实都触发 LLM。
+
+| 参数 | 推荐值 | 设太高 | 设太低 |
+| --- | --- | --- | --- |
+| `similarity_threshold` | 0.25 ~ 0.35 | 措辞差异大时漏检 | 无关记忆大量进候选，成本高 |
+
+**步骤 2：路由。**对相似度最高的候选，决定 ADD / UPDATE / DELETE：
+
+| 相似度区间 | 典型场景 | 动作 |
+| --- | --- | --- |
+| ≥ 0.85 + 否定词 | "讨厌披萨" vs "喜欢披萨" | DELETE |
+| ≥ 0.7 + 迁移词 | "已从 Java 转向 Go" | UPDATE |
+| ≥ 0.7 无矛盾 | "学了 Rust" + "用 Axum 实践" | UPDATE（细化） |
+| 0.5 ~ 0.7 | "喜欢意大利菜" + "最近在吃素" | ADD（并存） |
+| < 0.5 | 弱相关 | ADD（独立新信息） |
+
+示例代码用规则演示这套路由；线上通常把步骤 2 交给 LLM，因为"喜欢意大利菜"和"最近在吃素"并存，规则很容易误判成矛盾。
+
+```python
+def detect_conflict(new_fact, existing_memories, similarity_threshold=0.3):
+    """步骤 1 粗筛候选，步骤 2 对相似度最高的候选做路由"""
+    # --- 步骤 1：只保留 active 且相似度达标的记忆 ---
+    candidates = []
+    for mem in existing_memories:
+        if not mem["is_active"]:
+            continue
+        sim = embedding_similarity(new_fact, mem["content"])
+        if sim >= similarity_threshold:
+            candidates.append({**mem, "similarity": sim})
+
+    if not candidates:
+        return {"action": "ADD", "reason": "无相似记忆，独立新信息"}
+
+    top = max(candidates, key=lambda m: m["similarity"])
+
+    # --- 步骤 2：按相似度区间 + 关键词特征路由（见上表）---
+    if top["similarity"] >= 0.7:
+        has_negation = any(kw in new_fact for kw in ["不", "讨厌", "不喜欢"])
+
+        if has_negation and top["similarity"] >= 0.85:
+            return {"action": "DELETE", "target_id": top["id"],
+                    "reason": "直接矛盾，旧记忆标记遗忘"}
+        # 迁移（Java→Go）或细化补充（学了 Rust + 用 Axum）均走 UPDATE
+        return {"action": "UPDATE", "target_id": top["id"],
+                "reason": "时间演进或细化补充，旧版下线新版写入"}
+
+    if top["similarity"] >= 0.5:
+        return {"action": "ADD", "reason": "相关但不矛盾，并存保留"}
+
+    return {"action": "ADD", "reason": "弱相关，作为独立新信息写入"}
+```
+
+### 4.2 裁决执行：留版本链，不物理删除
+
+检测到冲突后，`x1_5_conflict_resolve.py` 演示怎么改库。**共同原则：数据不硬删，状态用字段标记，方便审计和回滚。**
+
+```python
+def resolve_conflict(memories_store, new_fact, action, target_id):
+    """执行 ADD / UPDATE / DELETE，均保留历史记录"""
+    if action == "UPDATE" and target_id:
+        # 旧版下线，新版上线，replaces 串起版本链
+        for mem in memories_store:
+            if mem["id"] == target_id:
+                mem["is_active"] = False
+                break
+        memories_store.append({
+            "content": new_fact,
+            "is_active": True,
+            "replaces": target_id,   # 可追溯：这条取代了谁
+        })
+
+    elif action == "DELETE" and target_id:
+        # 不删行，标记遗忘；检索时再 ×0.1，用户纠正后可恢复
+        for mem in memories_store:
+            if mem["id"] == target_id:
+                mem["is_active"] = False
+                mem["should_forget"] = True
+                break
+```
+
+Java → Go 的迁移走 UPDATE：旧版 `is_active=False` 留在库里，新版带 `replaces` 指向旧 id，日后可以回答"AI 为什么不推荐 Java 了"。直接否定（喜欢披萨 → 讨厌披萨）走 DELETE：旧版标记遗忘降权，而不是从磁盘抹掉，用户改口时还有恢复空间。
+
+### 4.3 确定性聚合：检索之后、进 Prompt 之前
+
+即便裁决正确，检索仍可能一次拉回多条记忆。全部塞进 Prompt 让 LLM 挑，同一问题问两遍，答案可能不同。`x1_6_retrieval_aggregate.py` 在代码层先做一轮合并：
+
+```python
+def deterministic_aggregate(candidates):
+    """同一话题只留 active 版本；多版本并存时才交给 LLM"""
+    topics = group_by_topic(candidates)
+    aggregated = []
+    for topic_name, group in topics.items():
+        active_mems = [m for m in group if m.get("is_active", True)]
+        if len(active_mems) == 1:
+            aggregated.append(active_mems[0])   # 单版本：代码直接定，结果可复现
+        elif len(active_mems) > 1:
+            aggregated.extend(active_mems)      # 并存偏好：上下文完整交给 LLM
+        # is_active=False 的旧版不进入 Prompt，省 Token
+    return aggregated
+```
+
+话题里只有一个 active 版本（比如当前主力语言 Go），代码层直接返回，省 Token，也保证两次查询结果一致。话题里多个 active 并存（意大利菜 + 近期吃素），才保留完整上下文，让 LLM 做综合判断。
+
+### 动手实验 4~6：走一遍冲突管线
+
+三个脚本建议按写入顺序跑，对应"检测 → 改库 → 检索后聚合"：
+
+```bash
+python x1_4_conflict_detect.py
+python x1_5_conflict_resolve.py
+python x1_6_retrieval_aggregate.py
+```
+
+`x1_4` 会打印每条测试事实的路由动作，重点看"喜欢意大利菜 + 最近在吃素"是不是 ADD 而非 DELETE。`x1_5` 改库后查 `is_active` 和 `replaces`，确认 Java 旧版还在、只是不再返回。`x1_6` 对比聚合前后 Token 估算，体会代码层先合并能省多少上下文。
+
+---
+
+## 总结与参考资料
+
+把四部分串起来，单 Agent 记忆的生命周期是这样运转的：
+
+1. **写入**：重要性打分 → `classify_memory_type` 定层级 → 初始 $S$ 确定
+2. **存续**：时间推移 + 访问次数 → 算 $R$ → 低于阈值标记遗忘
+3. **检索**：语义粗筛 → $R$ 参与精排 → 确定性聚合后再进 Prompt
+4. **冲突**：相似粗筛 → 路由裁决 → 版本链保留，旧版不硬删
+
+开篇的三个坑，在这里各有一条落点：衰减靠 $S$ 和 $\lambda$ 调优，矛盾靠写入时裁决，检索稳定性靠两阶段排序和聚合。中篇会把视角拉到多 Agent：同一个人的记忆，在不同工具之间该共享还是隔离。
+
+**参考资料：**
+
+1. [P3 Agent 记忆系统设计](https://datawhalechina.github.io/easy-data-x-ai/pm/P3%20%E8%AF%BE%E7%A8%8B%E7%A8%BF%EF%BC%9AAgent%20%E8%AE%B0%E5%BF%86%E7%B3%BB%E7%BB%9F%E8%AE%BE%E8%AE%A1.html)
+2. [D4 Agent 开发与记忆系统](https://datawhalechina.github.io/easy-data-x-ai/dev/D4%20%E8%AF%BE%E7%A8%8B%E7%A8%BF%EF%BC%9AAgent%20%E5%BC%80%E5%8F%91%E4%B8%8E%E8%AE%B0%E5%BF%86%E7%B3%BB%E7%BB%9F.html)
+3. LOCOMO Benchmark — [github.com/Shopify/locomo](https://github.com/Shopify/locomo)

--- a/docs/extra/X1-2 记忆的边界与信任.md
+++ b/docs/extra/X1-2 记忆的边界与信任.md
@@ -1,0 +1,295 @@
+# X1-2：记忆的边界与信任
+
+> Easy Data x AI 课程 · 扩展篇 · 中篇
+>
+> 上篇让单 Agent 会记、会忘、会裁决冲突。中篇回答：同一个人的记忆，在不同 Agent 之间该共享还是隔离？
+
+## 开篇
+
+上篇把单 Agent 的记忆生命周期跑通了：写入分层、算保留率 $R$、检索精排、冲突裁决。但现实中，用户很少只用一个 Agent。
+
+你可能用 Cursor 写代码，用 ChatGPT 做日常问答，用一个垂直工具管财务。它们都应该认识你，但**认识的程度不该一样**：
+
+- 财务工具需要知道收入结构和风险偏好，代码助手不需要
+- 代码助手需要知道技术栈偏好，财务工具不需要
+- 代码助手里未发布的产品细节，如果泄漏到联网的 ChatGPT 会话，就是安全事件
+
+**多 Agent 记忆的核心问题：同一个用户的数据，边界画在哪、共享怎么控、用户怎么信。**
+
+P3 从产品设计角度讲过命名空间和可见性档次。中篇用 `code/X1/part2_namespace/` 的示例代码，把设计落到存储层，串成一条链路：**隔离键默认互不可见 → 作用域按需共享 → 并发写入有仲裁 → 用户能查、能改、能删**。
+
+**目录**
+
+- [第一部分：命名空间与默认隔离](#第一部分命名空间与默认隔离)
+- [第二部分：作用域与权限提升](#第二部分作用域与权限提升)
+- [第三部分：共享架构与并发写入](#第三部分共享架构与并发写入)
+- [第四部分：信任治理的工程清单](#第四部分信任治理的工程清单)
+- [总结与参考资料](#总结与参考资料)
+
+## 第一部分：命名空间与默认隔离
+
+上篇始终在单个 Agent 里讨论记忆，存储层往往用 `user_id` 区分用户就够了。一旦第二个 Agent 接入，同一位用户下会并存多套记忆，若表结构里只有 `user_id`、没有 `agent_id`，这些条目混在同一命名空间里，隔离几乎无法事后补做。
+
+### 1.1 三级隔离键：写入时贴标签
+
+第一步是给每条记忆标明"属于谁"。示例代码 `x1_7_namespace_isolation.py` 在写入时为每条记忆带上三个字段：
+
+```
+user_id  →  agent_id  →  run_id
+```
+
+| 字段 | 隔离粒度 | 典型用途 |
+| --- | --- | --- |
+| `user_id` | 用户级 | 用户 A 与用户 B 完全隔离 |
+| `agent_id` | Agent 级 | 代码助手 vs 生活助手默认互不可见 |
+| `run_id` | 会话级 | 单次任务上下文，任务结束可清理 |
+
+写入时贴好标签，只是准备工作。**隔离是否生效，取决于检索时有没有先用这些标签过滤。**上篇两阶段检索里，阶段 1 也是先缩小候选集、再算语义；多 Agent 场景同理：必须先按 `user_id`、`agent_id` 圈定"当前 Agent 能看的子集"，再在这个子集里做语义匹配。
+
+但这个顺序不能反过来。如果先对全库做向量搜索、再在应用层做 `if mem["agent_id"] == agent_id` 过滤，会出现两个问题：
+
+1. **性能**：无关 Agent 的记忆也被拉回内存、参与相似度计算，向量索引的毫秒级优势丧失
+2. **安全**：被过滤掉的记忆可能已经经过 embedding 计算、写进日志或临时缓存，存在泄漏面
+
+因此隔离键必须在**查询构建阶段**注入，而不是检索后补救。下面的 `search()` 演示的就是这个顺序：先比对 `user_id` 和 `agent_id`，通过后才计算 `relevance`。
+
+```python
+class NamespaceMemoryStore:
+    def search(self, query, user_id, agent_id):
+        """先按隔离键过滤命名空间，再算语义相关度"""
+        results = []
+        for mem in self._store:
+            if mem["user_id"] != user_id:
+                continue          # 一级：跨用户不可见
+            if mem["agent_id"] != agent_id:
+                continue          # 二级：跨 Agent 默认不可见
+            if not mem["is_active"]:
+                continue
+            relevance = keyword_match(mem["content"], query)
+            if relevance > 0:
+                results.append(mem)
+        return results
+```
+
+上面循环里前两行 `continue`，就是在模拟生产环境中的两种等价写法：
+
+- 关系型存储：`WHERE user_id = ? AND agent_id = ?`，在 SQL 层只扫当前用户的当前 Agent 子集
+- 向量库：检索请求里带 metadata filter（`user_id`、`agent_id`），索引层直接跳过无关分区
+
+PowerMem 记忆系统也采用同样的"查询阶段注入过滤"思路。两种实现的对比如下：
+
+| 方式 | 与示例代码的对应 | 延迟 | 安全性 |
+| --- | --- | --- | --- |
+| **查询阶段过滤（推荐）** | `search()` 里先 `user_id`/`agent_id` 再 `relevance` | 低 | 高 |
+| **检索后过滤（不推荐）** | 先全表算 `relevance`，最后再 if 过滤 | 高 | 低 |
+
+### 1.2 动手实验 1：默认隔离是否生效
+
+`x1_7_namespace_isolation.py` 验证的正是上面这套顺序有没有落地：
+
+- Agent A（代码助手）写入 3 条技术记忆
+- Agent B（生活助手）写入 2 条生活记忆
+- 让 A 搜索"饮食 过敏"，预期**零结果**（B 的饮食记忆不应进入 A 的命名空间）
+
+```bash
+cd code/X1/part2_namespace
+python x1_7_namespace_isolation.py
+```
+
+若 A 能搜到 B 的记忆，说明隔离键没有在检索入口生效，这是 P0 级 bug，与上表"检索后过滤"的风险一致。
+
+`x1_9_cross_agent_query.py` 在 1000 条模拟数据上，量化"先过滤再检索"和"先检索再过滤"的延迟差。跑完可以直观看到：隔离不是多写两行 if 的事，而是**检索管线顺序**的设计问题。
+
+```bash
+python x1_9_cross_agent_query.py
+```
+
+第一部分解决的是"默认互不可见"。但姓名、角色、同组工具间的技术栈，有时确实也应该在多个 Agent 中进行共享。这就需要第二个维度：作用域。
+
+## 第二部分：作用域与权限提升
+
+`user_id` + `agent_id` 只能回答"这条记忆属于哪个 Agent"。它不能回答："同属 开发组的 PM 助手，能不能看到代码助手写的技术偏好？"
+
+作用域（Scope）就是在**同一用户、已有隔离键的前提下**，控制不同 Agent 之间能否看到某条记忆，这一部分管**经用户确认后，怎么有审计地打开**。
+
+### 2.1 四级作用域
+
+| 作用域 | 谁能看到 | 典型场景 |
+| --- | --- | --- |
+| `PRIVATE` | 仅写入该记忆的 Agent | 代码偏好、项目上下文 |
+| `AGENT_GROUP` | 同一 Agent Group 内所有 Agent | 开发工具组共享技术栈 |
+| `USER_GROUP` | 指定用户组可见 | 团队协作 |
+| `PUBLIC` | 所有 Agent | 姓名、角色等通用信息 |
+
+**默认值是 PRIVATE。** 记忆写入时不自动跨 Agent 流通；要共享，必须走 promote，并在审计日志里留痕。
+
+### 2.2 Promote：只能向更开放的方向移动
+
+沿用上面的例子：代码助手写入"用户主力语言 Go"，scope 为 PRIVATE。同组 PM 助手调用 `search()` 时，即使 `user_id` 相同、`agent_id` 不同，且 scope 仍为 PRIVATE，也**看不到**这条记忆。
+
+用户确认"开发组内可以共享技术栈"后，执行 promote：
+
+```python
+SCOPE_LEVEL = {"PRIVATE": 0, "AGENT_GROUP": 1, "PUBLIC": 2}
+
+def promote(self, memory_id, new_scope, target_group=None, actor_id="user"):
+    """提升作用域，并写入 audit_log 供事后追溯"""
+    for mem in self._store:
+        if mem["id"] != memory_id:
+            continue
+        old_scope = mem["scope"]
+        if SCOPE_LEVEL[new_scope] <= SCOPE_LEVEL[old_scope]:
+            return False  # 只能向更开放方向 promote，不能悄悄收回
+
+        mem["scope"] = new_scope
+        if target_group:
+            mem["target_group"] = target_group
+
+        self._audit_log.append({
+            "memory_id": memory_id,
+            "old_scope": old_scope,
+            "new_scope": new_scope,
+            "actor": actor_id,
+        })
+        return True
+    return False
+```
+
+`x1_8_promote_and_share.py` 把 promote 之后检索行为的变化跑一遍：
+
+1. 代码助手（dev_tools）写入技术偏好 → PRIVATE，PM 助手检索 → **看不到**
+2. promote 到 AGENT_GROUP(dev_tools) → PM 助手**现在可见**（检索逻辑会额外检查 scope 和 target_group）
+3. 生活助手（life_tools 组）检索 → **仍然看不到**
+
+```bash
+python x1_8_promote_and_share.py
+```
+
+用户问"AI 为什么知道我是后端工程师？"，`audit_log` 可以回答：某次 promote 把 PRIVATE 开放给了开发组。**信任靠可审计的变更链，不是靠黑盒推断。** LLM 可以建议是否 promote，决定权应在用户或业务规则。
+
+## 第三部分：共享架构与并发写入
+
+隔离键和作用域解决了**单套部署内**"谁能看到哪条记忆"。一旦记忆要跨设备、跨平台同步，或两个 Agent 同时写同一字段，还会遇到架构选型和并发仲裁问题。第三部分讨论的是**共享落地之后**的两类工程挑战。
+
+### 3.1 记忆跨平台时放哪：三种架构
+
+| 架构 | 代表 | 优势 | 代价 |
+| --- | --- | --- | --- |
+| **中心化记忆服务** | ChatGPT Memory | 一致性强，跨平台 | 数据主权低 |
+| **本地优先 + 选择性同步** | PowerMem 等 | 数据主权高，离线可用 | 多设备一致性弱 |
+| **点对点传递** | Agent 间 transfer | 最灵活 | 无全局视图，难管理 |
+
+没有绝对最优：**一致性、数据主权、跨平台能力，三者最多取二。** 这一节不跑示例脚本，而是帮你在 promote 之外补全"数据物理上怎么流动"的选型视角。合规要求高的内网倾向本地优先；快速接入倾向托管 API。
+
+### 3.2 边界设计仍可能失效的两类故障
+
+即使 isolation + scope 设计正确，上线后仍常见两类偏差，它们分别对应第二部分的两个维度：
+
+**工作记忆泄漏（scope 维度）：** 代码助手在调试中记住"用户最近失眠"。若 scope 误设为 PUBLIC，生活助手会在无关场景读到。缓解：敏感类别（健康、财务）写入时默认 PRIVATE，promote 前触发用户确认。
+
+**并发写入冲突（共享画像维度）：** 多个 Agent 写同一份共享用户画像时，Agent A 写"偏好 Python"，Agent B 同时写"主力 Go"。无版本控制时，后写覆盖先写，先写的更新静默丢失。这与上篇 Java→Go 的**冲突裁决**不同：那里是两条矛盾记忆，这里是**同一字段的并发写**。
+
+### 3.3 乐观锁：共享画像的最小仲裁
+
+`x1_10_concurrent_write.py` 针对 3.2 的并发冲突，对比三种写入策略：无保护、乐观锁、LWW。
+
+共享画像可建模为带 `version` 的结构化字段。两个 Agent 同时改 `preferred_language` 时，乐观锁用 CAS（Compare-And-Swap）检测"读到的版本是否仍是最新"：
+
+```python
+shared_profile = {"preferred_language": "Java", "version": 1}
+
+# Agent A：读到 version=1，尝试改为 Go
+current_version = shared_profile["version"]
+if shared_profile["version"] == current_version:
+    shared_profile["preferred_language"] = "Go"
+    shared_profile["version"] += 1          # 写入成功，version → 2
+
+# Agent B：也读到 version=1，但 A 已改为 2 → 条件不成立，需重读再合并
+if shared_profile["version"] != current_version:
+    pass  # 冲突：重试或交给用户仲裁
+```
+
+| 策略 | 优点 | 缺点 |
+| --- | --- | --- |
+| 无保护 | 实现简单 | 静默覆盖，数据丢失 |
+| 乐观锁 | 低开销，可重试 | 高冲突时需人工仲裁 |
+| LWW | 实现简单 | 后写覆盖前写，可能丢合理更新 |
+
+不同 Agent 更新画像的不同 key 时通常无冲突；同一 key 需要仲裁时，乐观锁是成本最低的方案。
+
+### 动手实验 2：并发写入谁赢
+
+```bash
+python x1_10_concurrent_write.py
+```
+
+对照输出：无保护策略下，是否总有一个 Agent 的更新被覆盖？乐观锁下，失败写入有没有触发重试？这对应 3.2 里"并发写入冲突"的缓解路径。
+
+## 第四部分：信任治理的工程清单
+
+前三部分解决的是**系统怎么画边界**：隔离键、作用域、并发仲裁。但开篇第三个问题"用户怎么信"，还需要用户侧能**看见、修正、删除、理解影响**。否则 promote 和隔离对用户仍是黑盒。
+
+P3 从产品角度提过这四类能力。工程上它们对应一组 API，并与第二部分的 `audit_log` 衔接：
+
+### 4.1 面向用户的记忆管理 API
+
+| 能力 | API 形态 | 与前面章节的关联 |
+| --- | --- | --- |
+| **查看** | `GET /memories?scope=all` | 展示各 scope 下的记忆，而非原始行 dump |
+| **修正** | `PUT /memories/{id}` | 修正后检查是否与同话题其他记忆冲突（上篇冲突管线） |
+| **删除** | `DELETE /memories/{id}` | 级联清理主库、向量索引、缓存（见下表） |
+| **理解影响** | `GET /memories/{id}/impact` | 删除后哪些 Agent、哪些 query 的回答会变 |
+
+用户需要的是"AI 眼中的我"，有上下文、有操作入口，而不是 `{ "mem_003": "用户用 Go" }` 这样的原始字段。
+
+### 4.2 合规与安全
+
+多 Agent 场景下，一条记忆往往同时存在于主库、向量索引、缓存甚至备份里；promote 还会改变谁能看到它。下面三项是上线前常见的检查清单。
+
+| 项 | 工程要点 | 与前面章节的关联 |
+| --- | --- | --- |
+| **被遗忘权** | 主库 + 向量索引 + 缓存 + 备份都要清 | 第一部分：embedding 也可能携带隔离键外的内容 |
+| **记忆投毒防护** | 来源置信度、高敏感门控 | 第二部分：错误 promote 会把恶意内容扩 scope |
+| **审计日志** | 谁、何时、改了 scope 或内容 | 第二部分：`audit_log` 的用户-facing 延伸 |
+
+**被遗忘权（用户要求删除某条记忆）**
+
+用户点删除时，不能只删数据库里的一行。检索链路里，同一条记忆可能有多份副本：
+
+| 存储位置 | 若只删主库会怎样 |
+| --- | --- |
+| 主库（记忆正文） | 已删，但检索仍可能命中旧副本 |
+| 向量索引（embedding） | 语义搜索还能召回已删内容 |
+| 缓存（近期检索结果） | 短时间内 Agent 仍用旧答案 |
+| 备份 / 日志 | 合规上仍算"未彻底删除" |
+
+工程上应为 `DELETE /memories/{id}` 设计**级联清理**：主库标记删除 → 异步删向量索引中的对应 embedding → 失效相关缓存 key → 备份保留策略与主库一致。第一部分讲过，检索先过隔离键再过语义；删除时也要按同样思路，把记忆流经的每个出口都走到。
+
+**记忆投毒防护（恶意内容被当成用户事实）**
+
+攻击者可能通过对话注入"用户偏好 XXX"，系统提炼后写入记忆，再被 promote 扩大可见范围。缓解思路：
+
+- **写入前**：对来源做置信度标记（用户亲口说的 vs 外部链接解析出的）
+- **promote 前**：健康、财务、身份类记忆强制用户二次确认（对应第二部分的 scope 提升流程）
+- **高敏感类别**：默认 PRIVATE，不允许 LLM 自动 promote 到 PUBLIC
+
+**审计日志（事后追溯"AI 凭什么知道"）**
+
+第二部分 `promote()` 里的 `audit_log`，记录谁在何时把哪条记忆从 PRIVATE 改到 AGENT_GROUP。合规场景下还需要覆盖：谁删除了记忆、谁修正了内容。用户投诉或监管问询时，能还原完整变更链，而不是只有当前快照。
+
+上线前可以自问三件事：删一条记忆时四个存储出口是否都覆盖？promote 敏感记忆有没有人工或规则门禁？scope 和内容变更是否可查？
+
+## 总结与参考资料
+
+中篇把多 Agent 记忆的工程核心归纳为三条，并与开篇问题一一对应：
+
+1. **命名空间从第一天就要有**（默认互不可见）：`user_id` + `agent_id` 在检索入口过滤，再谈语义
+2. **默认隔离、显式共享**（共享怎么控）：PRIVATE 为默认，promote 可审计；敏感记忆不应自动跨 Agent 流通
+3. **信任是 API + 审计**（用户怎么信）：用户能查、改、删、理解影响；删除与 promote 都可追溯
+
+**逻辑链：** 上篇单 Agent 生命周期 → 中篇多 Agent 边界与信任 → 下篇从海量记忆中蒸馏稳定认知，并量化系统好不好。
+
+**参考资料：**
+
+1. [P3 Agent 记忆系统设计](https://datawhalechina.github.io/easy-data-x-ai/pm/P3%20%E8%AF%BE%E7%A8%8B%E7%A8%BF%EF%BC%9AAgent%20%E8%AE%B0%E5%BF%86%E7%B3%BB%E7%BB%9F%E8%AE%BE%E8%AE%A1.html)
+2. ChatGPT Memory 产品文档 — [openai.com/index/memory-and-new-controls-for-chatgpt](https://openai.com/index/memory-and-new-controls-for-chatgpt/)

--- a/docs/extra/X1-3 从记忆到认知.md
+++ b/docs/extra/X1-3 从记忆到认知.md
@@ -1,0 +1,317 @@
+# X1-3：从记忆到认知
+
+> Easy Data x AI 课程 · 扩展篇 · 下篇
+>
+> 【上篇】和中篇解决了单 Agent 生命周期与多 Agent 边界。下篇回答：记忆堆多了之后，怎么蒸馏出稳定认知？怎么知道系统记得好不好？
+
+## 开篇
+
+【上篇】让单 Agent 会记、会忘、会裁决冲突；中篇划清了多 Agent 之间的隔离与共享。到这里，记忆系统已经能稳定运转。但条目一多，新问题浮现：
+
+1. **该永久保留什么？** 原始对话越堆越多，Prompt 里塞不下，也不该全塞
+2. **弱信号怎么升华？** 单条不重要，多条拼起来却是重要事实（在【上篇】中提到的被动巩固的盲区）
+3. **怎么证明记得好？** 衰减参数、冲突策略调完，凭什么说比 Mem0 / 全量上下文更好
+
+下篇用 `code/X1/part3_consolidation/` 的示例代码，串成两条线：**巩固（怎么从海量条目里提纯认知）→ 评测（怎么量化质量并选型）**。
+
+**目录**
+
+- [第一部分：永久记忆意味着什么](#第一部分永久记忆意味着什么)
+- [第二部分：三种巩固触发方式](#第二部分三种巩固触发方式)
+- [第三部分：画像与事实库为什么要分开](#第三部分画像与事实库为什么要分开)
+- [第四部分：从经验到 Skill](#第四部分从经验到-skill)
+- [第五部分：评测与选型](#第五部分评测与选型)
+- [总结与参考资料](#总结与参考资料)
+
+## 第一部分：永久记忆意味着什么
+
+上下文窗口涨到 1M tokens 之后，常见疑问是：直接把历史对话全塞进去不就行了？但实际上不是这样的。
+
+有三个原因让"全量塞窗口"在工程上不可持续：
+
+1. **成本**：注意力随长度近似平方增长，百万 token 单次推理成本是万级的上百倍
+2. **精度**：lost-in-the-middle 现象下，窗口越大，中间信息越容易被漏掉；语义检索 + 衰减精排往往更准
+3. **数据主权**：窗口里的数据随会话消失，无法独立管理、审计、删除；记忆库才是持久层
+
+**记忆不是窗口的临时替代品，而是独立的基础设施。** 下篇讨论的"永久记忆"，也不是永不删除，而是：
+
+> 进入衰减极慢的稳定层 + 具备蒸馏为更高阶结构（画像、经验、Skill）的能力
+
+【上篇】讲过 working / short_term / long_term 三层和层级倍率。这里从认知角度再看一遍筛选链路：
+
+```
+新信息 → working（快速淘汰）→ short_term（近期信号）→ long_term（稳定认知，可蒸馏）
+```
+
+| 层级 | 承接量 | 职责 |
+| --- | --- | --- |
+| working | 百条/会话级 | 承接原始输入 |
+| short_term | 数十条 | 保留近期有价值信号 |
+| long_term | 十几条核心 | 存储稳定认知，可写入画像 |
+
+**目标不是存更多，而是淘汰不重要的、提纯重要的。** D4 讲过 CoALA 的三种长期记忆（语义、情景、程序），工程上存储方式差异很大：语义走向量检索，程序是 System Prompt，情景常以 few-shot 注入。第三节会专门讨论怎么把"确定性画像"和"长尾事实"分开存。
+
+## 第二部分：三种巩固触发方式
+
+一条记忆从临时印象变成长期认知，需要**巩固（Consolidation）**。在【上篇】的 2.1 节的被动巩固（写入时按 importance 分层）只覆盖一种触发；示例代码演示三种方式，对应不同业务节奏。
+
+### 2.1 被动触发：写入时的一次分流
+
+【上篇】已讲过 `classify_memory_type`：importance ≥ 0.8 进 long_term，0.6~0.8 进 short_term，其余进 working。`x1_11_consolidation_passive.py` 用 6 条记忆验证分层与 30 天后 $R$ 的差异：
+
+| 内容 | 重要性 | 层级 | 30 天后 $R$（约） |
+| --- | --- | --- | --- |
+| 对花生过敏 | 0.95 | long_term | > 0.7 |
+| 主力 Go，8 年经验 | 0.85 | long_term | > 0.7 |
+| 电商项目 Django + PG | 0.72 | short_term | 中等 |
+| 偏好简洁代码风格 | 0.65 | short_term | 中等 |
+| 考虑学 Kubernetes | 0.55 | working | 接近 0 |
+| 今天早上喝了咖啡 | 0.20 | working | 接近 0 |
+
+优点：**写入瞬间完成，零额外 LLM 成本。** 局限：只看单条，发现不了"连续三周搜 Rust 教程"这种跨条目模式。
+
+### 2.2 主动触发：Reflection 蒸馏
+
+【上篇】 2.1 末尾留过这个坑：多条 short_term 拼在一起，可能隐含一个 stable 事实。这就是**主动触发（Reflection）**：周期性扫描近期记忆，按话题分组后让 LLM 判断能否蒸馏。
+
+`x1_12_consolidation_reflection.py` 读取 `fixtures/reflection_input.json`（10 条记忆，4 个话题）。以 Rust 学习为例，5 条单独看 importance 都不高：
+
+- 用户在看 Rust 教程
+- 用户问了生命周期问题
+- 用户搭建了 Rust 开发环境
+- 用户在使用 Axum 框架
+- 用户遇到 ownership 问题
+
+放在一起，可以蒸馏为：
+
+> 用户正在系统学习 Rust，已搭建开发环境并使用 Axum 实践，目前处于初学者阶段
+
+```python
+def reflection_analyze(topic, memories, min_count=3, min_confidence=0.7):
+    """按话题扫描近期记忆，蒸馏为稳定事实（生产环境由 LLM 完成）"""
+    if len(memories) < min_count:
+        return None  # 证据不足，继续在中期层等待
+
+    distilled_fact = llm_summarize(topic, memories)
+    confidence = llm_confidence(topic, memories)
+
+    return {
+        "distilled_fact": distilled_fact,
+        "confidence": confidence,
+        "action": "consolidate_to_long_term"
+                  if confidence >= min_confidence
+                  else "keep_in_short_term",
+    }
+```
+
+| 参数 | 含义 | 为什么需要 |
+| --- | --- | --- |
+| `min_count` | 至少几条独立记忆才触发 | 避免单条孤证直接入 long_term |
+| `min_confidence` | 置信度阈值 | 不达标则保留在 short_term，等待更多证据 |
+
+### 2.3 懒惰触发：检索达阈值再总结
+
+第三种是**懒惰触发**：某类记忆被检索 $N$ 次后才批量提取。比如用户第 5 次问"推荐 Python 框架"，系统才总结"偏好 Django，对 Flask 不感兴趣"。成本按需发生，适合偏好类、高频话题。
+
+| 触发方式 | 时机 | 成本 | 适用 |
+| --- | --- | --- | --- |
+| 被动 | 写入瞬间 | 最低 | 过敏、职业等单条高重要性事实 |
+| 主动 | 周期性扫描 | 中等 | 多条弱信号拼成强事实 |
+| 懒惰 | 检索达阈值 | 按需 | 偏好类、高频查询话题 |
+
+三种方式互补：【上篇】解决单条怎么衰减，本节解决多条怎么升华。
+
+### 动手实验 1~2：巩固链路
+
+```bash
+cd code/X1/part3_consolidation
+python x1_11_consolidation_passive.py
+python x1_12_consolidation_reflection.py
+```
+
+跑 `x1_12` 时重点看：哪些话题因 `min_count` 或 `min_confidence` 未达标而留在中期层？蒸馏后长期事实条数 vs 原始记忆条数的压缩比是多少？
+
+## 第三部分：画像与事实库为什么要分开
+
+巩固之后，长期认知有两种典型形态：**结构化画像**（姓名、主力语言、云平台）和**长尾事实**（某次用 Django 处理百万行 CSV 的细节）。混在一起存，检索时容易两头吃亏。
+
+| | 用户画像 | 向量事实库 |
+| --- | --- | --- |
+| 变化频度 | 慢（几周才变） | 快（每次对话都可能写入） |
+| 更新方式 | 覆盖式 | 增量 append |
+| 查询方式 | 按 key 精确读取 | 语义模糊匹配 |
+| 条目数 | 固定几十个字段 | 无上限 |
+| 典型内容 | 技术栈、角色、核心偏好 | 项目细节、对话上下文 |
+
+`x1_13_profile_vs_facts.py` 对比三种检索方式，并演示**组合策略：先画像、后事实库**：
+
+```python
+def query_combined(profile, facts, query):
+    """画像给确定性约束，事实库补长尾"""
+    # 路径 1：按 key 精确匹配，"用户用 Go" 不会被语义搜索漏掉
+    deterministic = {}
+    for key, value in flatten(profile).items():
+        if keyword_match(key, query) or keyword_match(value, query):
+            deterministic[key] = value
+
+    # 路径 2：事实库语义搜索，覆盖画像字段以外的细节
+    contextual = semantic_search(query, facts, top_n=5)
+
+    return {"deterministic": deterministic, "contextual": contextual}
+```
+
+用户问"推荐后端技术方案"时，画像路径返回 `primary_language: Go`、`cloud: 阿里云`；事实库路径补充"曾用 Django 处理百万行 CSV"这类长尾。两者进 Prompt，LLM 既不会漏核心约束，也不会只剩干巴巴的几个字段。
+
+### 动手实验 3：三种检索方式对比
+
+```bash
+python x1_13_profile_vs_facts.py
+```
+
+对照输出：仅画像、仅事实库、组合检索在同一 query 下差在哪？有没有"仅事实库"时漏掉 `primary_language` 的情况？
+
+## 第四部分：从经验到 Skill
+
+巩固解决"记什么"，经验蒸馏解决"记了怎么用"。多轮成功交互可结构化为三元组：
+
+```
+(问题情境, 采取方案, 结果)
+```
+
+`x1_14_experience_distill.py` 演示三步：`extract_experience_triples` → `cluster_experiences` → 外化为 Skill 描述。
+
+```python
+from collections import defaultdict
+
+def extract_experience_triples(episodic_memories):
+    """从情景记忆提取 (问题, 方案, 结果)"""
+    triples = []
+    for mem in episodic_memories:
+        triples.append({
+            "problem": mem["problem"],
+            "solution": mem["solution"],
+            "result": mem["result"],
+            "domain": mem["domain"],
+            "success": "成功" in mem["result"],
+        })
+    return triples
+
+def cluster_experiences(triples):
+    """同类成功经验聚类，归纳为可复用模式（生产环境由 LLM 完成）"""
+    by_domain = defaultdict(list)
+    for t in triples:
+        if t["success"]:
+            by_domain[t["domain"]].append(t)
+
+    patterns = {}
+    for domain, exp_list in by_domain.items():
+        if len(exp_list) >= 2:
+            patterns[domain] = induce_pattern(domain, exp_list)
+    return patterns
+```
+
+两条"数据处理"成功经验可能归纳为："处理大文件时，优先推荐 Python/pandas 的 chunked reading"。置信度达标后，可外化为 Skill 规则注入 System Prompt。P4 讨论的 Skill 知识管理中，一部分规则就来自这条路径：**记忆系统输出经验，Skill 系统输出行为规则。**
+
+### 动手实验 4：经验到 Skill 雏形
+
+```bash
+python x1_14_experience_distill.py
+```
+
+看输出里哪些 domain 聚类成功、哪些因样本不足未形成模式。Think：这些 Skill 雏形若写入 System Prompt，Agent 行为会和"仅检索记忆"有何不同？
+
+## 第五部分：评测与选型
+
+巩固和架构设计回答"怎么记好"。上线前还要回答：**怎么证明记得好？** 否则 $\lambda$、归档阈值、冲突策略都是在猜。
+
+### 5.1 公开基准在测什么
+
+| 基准 | 侧重 | 关键结论 |
+| --- | --- | --- |
+| **LOCOMO** | 长期对话 + 时序推理 | 有选择记忆 + 衰减（78.7%）> 全量记住（52.9%） |
+| **MemoryAgentBench** | 事实、偏好更新、冲突、遗忘 | 多跳冲突和遗忘是共同短板 |
+| **MemoryArena** | 记忆驱动行动 | 光 recall 不够，须影响 Agent 决策 |
+| **AppWorld** | 长程任务 | 有记忆管理在 Token 和通过率上均优于无记忆 |
+
+LOCOMO 的结论与【上篇】呼应：**不是记得越多越好。** 有选择地记 + 主动忘，反而比全量堆窗口准确。
+
+### 5.2 不止看准确率
+
+| 维度 | 指标 | 为什么重要 |
+| --- | --- | --- |
+| **准确性** | 事实召回率、冲突裁决正确率 | 基本功 |
+| **效率** | Token 消耗、检索 P99 | 20 条 × 200 tokens = 4000 tokens/对话 |
+| **成本** | 每千条存储空间 | 向量索引长期运营成本 |
+| **鲁棒性** | 冲突可逆性、隔离泄漏率 | 中篇 scope 设计是否有效 |
+| **一致性** | 同一 query 两次回答方差 | 【上篇】确定性聚合是否生效 |
+
+`x1_15_benchmark_runner.py` 在同一套记忆和 QA 对上，切换不同 $\lambda$ 跑分：
+
+```python
+def run_benchmark(memories, qa_pairs, decay_rate, strategy_name):
+    """对比不同衰减策略的准确率、Token、延迟"""
+    correct, total_tokens, latencies = 0, 0, []
+
+    for q in qa_pairs:
+        results, tokens, latency = search_memories(
+            memories, q["question"], decay_rate
+        )
+        if evaluate_answer(results, q["expected_answer"]):
+            correct += 1
+        total_tokens += tokens
+        latencies.append(latency)
+
+    p99_idx = int(len(latencies) * 0.99) if latencies else 0
+    return {
+        "strategy": strategy_name,
+        "decay_rate": decay_rate,
+        "accuracy": correct / len(qa_pairs),
+        "avg_tokens_per_query": total_tokens / len(qa_pairs),
+        "p99_latency_ms": sorted(latencies)[p99_idx] if latencies else 0,
+    }
+```
+
+输入来自 `fixtures/eval_qa_pairs.json`。同一套数据、换 $\lambda$ 跑一遍，三项指标并排对比，比对着功能清单选型靠谱得多。
+
+### 5.3 行业方案怎么选
+
+| 类型 | 代表 | 核心思路 | 适合 |
+| --- | --- | --- | --- |
+| **托管 API** | Mem0 | LLM 自动管理生命周期 | 快速接入 |
+| **时序知识图谱** | Zep / Graphiti | 关系 + 时间显式建模 | 需要历史追溯 |
+| **Agent 自编辑** | Letta | Agent 自主读写记忆块 | 长程自主 Agent |
+| **本地优先** | PowerMem | 混合检索 + 衰减 + 本地存储 | 数据主权敏感 |
+
+建议流程：整理 50~100 条业务 QA → 在 LOCOMO 子集或自建集上跑分 → 准确率达标后，选 Token + 延迟 + 成本最低的方案。
+
+### 动手实验 5：跑一遍简易评测
+
+```bash
+python x1_15_benchmark_runner.py
+```
+
+对照不同 $\lambda$ 的准确率和 Token：误忘率高就调大 $\lambda$（【上篇】 2.2）；Token 爆就收紧 Top-N 或加强聚合（【上篇】 3.1、4.3）；隔离泄漏就收紧默认 scope（中篇 2.1）。**评测结果应回流改参数，而不是只跑一遍看热闹。**
+
+## 总结与参考资料
+
+X1 系列三篇形成完整逻辑链：
+
+| 篇 | 核心问题 | 关键机制 |
+| --- | --- | --- |
+| 上篇 | 单 Agent 怎么记好 | 衰减 → 分层 → 检索精排 → 冲突裁决 → 聚合 |
+| 中篇 | 多 Agent 边界在哪 | 隔离键 → 作用域 → promote → 信任 API |
+| 下篇 | 怎么蒸馏认知、怎么量化 | 三种巩固 → 画像/事实分离 → 经验→Skill → 评测 |
+
+下篇四条要点：
+
+1. **永久记忆 = 稳定层 + 蒸馏能力**，不是无限堆原始对话
+2. **画像和事实库分离**：确定性走精确读取，长尾走向量搜索
+3. **记忆 → 经验 → Skill 形成闭环**，衔接 P4 Skill 体系
+4. **选型先定指标再跑分**，功能清单不能代替 LOCOMO 或自建 QA 集
+
+**参考资料：**
+
+1. [D4 Agent 开发与记忆系统](https://datawhalechina.github.io/easy-data-x-ai/dev/D4%20%E8%AF%BE%E7%A8%8BF%EF%BC%9AAgent%20%E5%BC%80%E5%8F%91%E4%B8%8E%E8%AE%B0%E5%BF%86%E7%B3%BB%E7%BB%9F.html)
+2. CoALA — [arxiv.org/abs/2309.02427](https://arxiv.org/abs/2309.02427)
+3. LOCOMO Benchmark — [github.com/Shopify/locomo](https://github.com/Shopify/locomo)
+4. [P4 Skill 与 Agent 知识管理](https://datawhalechina.github.io/easy-data-x-ai/pm/P4%20%E8%AF%BE%E7%A8%8B%E7%A8%BF%EF%BC%9ASkill%20%E4%B8%8E%20Agent%20%E7%9F%A5%E8%AF%86%E7%AE%A1%E7%90%86.html)


### PR DESCRIPTION
## Summary

认领 [#36](https://github.com/datawhalechina/easy-data-x-ai/issues/36)，完成扩展篇 X1「探究 AI Agent 记忆系统：从遗忘曲线到永久记忆」系列内容：

- **系列导读**：更新 docs/extra/X1 探究 AI Agent 记忆系统：从遗忘曲线到永久记忆.md，由占位页改为三篇导读
- **X1-1 记忆的生命周期工程**：单 Agent 场景下的衰减策略与冲突检测/裁决管线（对应共建任务 #19 / #21）
- **X1-2 记忆的边界与信任**：多 Agent 命名空间隔离、共享与信任治理（对应共建任务 #20）
- **X1-3 从记忆到认知**：巩固机制、永久记忆架构、评测与选型
- **配套代码**：code/X1/ 下 15 个可运行 Python 实验脚本 + JSON fixtures，覆盖三篇核心实验
- **导航更新**：VitePress 侧边栏将 X1 展开为系列子目录

## Test plan

- [x] 本地运行 code/X1/part1_decay_conflict/x1_1_decay_score_demo.py 验证示例可执行
- [x] 本地 
pm run docs:dev 预览三篇文档与侧边栏导航