### PR TITLE
docs: 完善 D2 补充高级 Chunking 策略对比实验

### DIFF
--- a/code/D2/d2_5_chunking_compare.py
+++ b/code/D2/d2_5_chunking_compare.py
@@ -1,0 +1,336 @@
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from openai import OpenAI, OpenAIError
+
+from config import Config
+
+if __package__:
+    from .d2_chunking_strategies import (
+        dynamic_overlap_chunk,
+        fixed_overlap_chunk,
+        flatten_parent_child,
+        parent_child_chunk,
+        semantic_chunk,
+    )
+else:
+    from d2_chunking_strategies import (
+        dynamic_overlap_chunk,
+        fixed_overlap_chunk,
+        flatten_parent_child,
+        parent_child_chunk,
+        semantic_chunk,
+    )
+
+# ============================================================
+# d2_5：高级 Chunking 策略对比实验
+#
+# 对比三种策略 + 固定 overlap 基线：
+#   1. 固定 overlap（基线）
+#   2. 语义分块
+#   3. 动态 overlap
+#   4. 父子 chunk（子块检索 → 父块上下文）
+#
+# 运行前：
+#   - pip install pyseekdb openai
+#   - 优先使用 seekdb 向量检索；不可用时自动降级为内存检索
+#   - 语义分块需要配置 SILICONFLOW_API_KEY（见 .env.example）
+#
+# 给学生的背景说明：
+#   - 本实验同时包含「分块阶段」和「检索阶段」两个维度。
+#   - seekdb 嵌入式模式不可用时，只影响检索后端，会降级为内存词项匹配。
+#   - SILICONFLOW_API_KEY 只用于语义分块阶段的句子 Embedding。
+#   - 因此：seekdb 降级不代表 API Key 无效；配置了 Key 仍会运行语义分块。
+# ============================================================
+
+
+SAMPLE_LONG_DOC = """
+# 数据库运维手册
+
+## 错误码参考
+
+错误码 E-4011 表示连接被拒绝。解决方案：确认数据库服务是否正在运行，检查防火墙规则是否允许对应端口的访问。若服务正常但仍被拒绝，请核对白名单配置。
+
+错误码 E-4012 表示数据库连接超时。解决方案：检查网络配置，确认数据库服务端口是否开放，建议超时时间设置为 30 秒。同时检查中间网络设备是否存在丢包。
+
+错误码 E-4013 表示认证失败。解决方案：检查用户名和密码是否正确，确认账户是否被锁定。如果账户被锁定，需要联系管理员解锁后重试。
+
+## 性能优化
+
+数据库查询性能优化指南：合理使用索引可以将查询速度提升 10 倍以上。建议对高频查询的 WHERE 条件列建立索引。避免在索引列上使用函数，否则会导致索引失效。
+
+执行计划分析是定位慢查询的关键步骤。开启慢查询日志后，优先优化扫描行数最多的 SQL。对于大表分页，推荐使用延迟关联或游标分页替代深分页 OFFSET。
+
+## 访问控制
+
+访问控制架构设计：基于 RBAC 模型实现用户权限管理，支持角色继承和细粒度的资源级权限控制。建议按最小权限原则分配角色，定期审计权限配置。
+
+多租户场景下，应在连接层注入租户标识，并在 SQL 层强制附加租户过滤条件，避免跨租户数据泄露。
+
+## 版本发布
+
+OB-4.2.1 版本新特性：支持在线 DDL 操作、改进了并行查询引擎、修复了分区表在特定条件下的数据倾斜问题。升级前请备份数据并阅读升级指南。
+
+## 备份与恢复
+
+数据备份与恢复：建议每天进行全量备份，每小时进行增量备份。恢复时优先使用最近的全量备份，再应用增量备份。备份文件应存储在独立的存储介质上。
+
+## 连接池配置
+
+连接池配置最佳实践：最大连接数建议设置为 CPU 核心数的 2-4 倍。连接超时时间建议设置为 30 秒，空闲连接超时建议设置为 600 秒。监控活跃连接数，避免连接泄漏。
+""".strip()
+
+
+EVAL_QUERIES = [
+    {"query": "错误码 E-4012 连接超时怎么解决", "keyword": "E-4012"},
+    {"query": "RBAC 角色权限如何设计", "keyword": "RBAC"},
+    {"query": "OB-4.2.1 在线 DDL 新特性", "keyword": "在线 DDL"},
+    {"query": "连接池最大连接数设多少", "keyword": "连接池"},
+    {"query": "慢查询执行计划怎么分析", "keyword": "执行计划"},
+]
+
+
+def _extract_query_terms(query: str) -> list[str]:
+    """从查询中提取中英文关键词片段。"""
+    terms = re.findall(r"[A-Za-z0-9][\w.-]*|[\u4e00-\u9fff]{2,}", query)
+    return [t for t in terms if len(t) >= 2]
+
+
+def _lexical_score(query: str, text: str) -> float:
+    terms = _extract_query_terms(query)
+    if not terms:
+        return 0.0
+    return sum(1.0 for term in terms if term in text)
+
+
+class InMemoryRetriever:
+    """seekdb 不可用时的降级检索器（词项匹配打分）。"""
+
+    def __init__(self, texts: list[str], metadatas: list[dict]):
+        self.texts = texts
+        self.metadatas = metadatas
+
+    def search(self, query: str, k: int = 3) -> list[str]:
+        scored = [
+            (_lexical_score(query, text), idx)
+            for idx, text in enumerate(self.texts)
+        ]
+        scored.sort(key=lambda item: item[0], reverse=True)
+        top_indices = [idx for _, idx in scored[:k]]
+        return [self.texts[idx] for idx in top_indices]
+
+    def search_with_context(self, query: str, k: int = 3) -> list[str]:
+        scored = [
+            (_lexical_score(query, text), idx)
+            for idx, text in enumerate(self.texts)
+        ]
+        scored.sort(key=lambda item: item[0], reverse=True)
+        contexts: list[str] = []
+        for _, idx in scored[:k]:
+            contexts.append(self.texts[idx])
+            parent_text = self.metadatas[idx].get("parent_text", "")
+            if parent_text:
+                contexts.append(parent_text)
+        return contexts
+
+
+class SeekdbRetriever:
+    """基于 pyseekdb 的向量检索器。"""
+
+    def __init__(self, collection):
+        self.collection = collection
+
+    def search(self, query: str, k: int = 3) -> list[str]:
+        results = self.collection.query(query_texts=[query], n_results=k)
+        return results.get("documents", [[]])[0]
+
+    def search_with_context(self, query: str, k: int = 3) -> list[str]:
+        results = self.collection.query(query_texts=[query], n_results=k)
+        docs = results.get("documents", [[]])[0]
+        metas = results.get("metadatas", [[]])[0]
+        contexts = list(docs)
+        for meta in metas:
+            parent_text = meta.get("parent_text", "")
+            if parent_text:
+                contexts.append(parent_text)
+        return contexts
+
+
+def build_embed_fn():
+    api_key = Config.SILICONFLOW_API_KEY
+    if not api_key or api_key == "YOUR_API_KEY":
+        raise RuntimeError("语义分块需要 SILICONFLOW_API_KEY，请在 code/.env 中配置")
+
+    client = OpenAI(
+        api_key=Config.SILICONFLOW_API_KEY,
+        base_url=Config.SILICONFLOW_BASE_URL,
+    )
+
+    def embed_batch(texts: list[str]) -> list[list[float]]:
+        response = client.embeddings.create(model="BAAI/bge-m3", input=texts)
+        return [item.embedding for item in response.data]
+
+    return embed_batch
+
+
+def has_siliconflow_key() -> bool:
+    api_key = Config.SILICONFLOW_API_KEY
+    return bool(api_key and api_key != "YOUR_API_KEY")
+
+
+def prepare_strategy_chunks(strategy: str) -> tuple[list[str], list[dict]]:
+    if strategy == "fixed":
+        texts = fixed_overlap_chunk(SAMPLE_LONG_DOC, chunk_size=200, overlap=30)
+        return texts, [{"strategy": strategy} for _ in texts]
+
+    if strategy == "semantic":
+        texts = semantic_chunk(SAMPLE_LONG_DOC, build_embed_fn())
+        return texts, [{"strategy": strategy} for _ in texts]
+
+    if strategy == "dynamic":
+        texts = dynamic_overlap_chunk(SAMPLE_LONG_DOC, chunk_size=200)
+        return texts, [{"strategy": strategy} for _ in texts]
+
+    if strategy == "parent_child":
+        parents = parent_child_chunk(SAMPLE_LONG_DOC, parent_size=500, child_size=120)
+        return flatten_parent_child(parents)
+
+    raise ValueError(f"未知策略：{strategy}")
+
+
+def create_seekdb_retriever(strategy: str, use_parent_context: bool) -> SeekdbRetriever | None:
+    try:
+        import pyseekdb
+    except ImportError:
+        return None
+
+    try:
+        db = pyseekdb.Client()
+    except ValueError:
+        return None
+
+    coll_name = f"d2_chunking_{strategy}"
+    if db.has_collection(coll_name):
+        db.delete_collection(coll_name)
+    collection = db.create_collection(name=coll_name)
+
+    texts, metadatas = prepare_strategy_chunks(strategy)
+    collection.add(
+        ids=[f"chunk_{i}" for i in range(len(texts))],
+        documents=texts,
+        metadatas=metadatas,
+    )
+    retriever = SeekdbRetriever(collection)
+    retriever.use_parent_context = use_parent_context
+    retriever.chunk_count = len(texts)
+    retriever.avg_chunk_size = sum(len(t) for t in texts) / max(len(texts), 1)
+    return retriever
+
+
+def create_memory_retriever(strategy: str) -> InMemoryRetriever:
+    texts, metadatas = prepare_strategy_chunks(strategy)
+    retriever = InMemoryRetriever(texts, metadatas)
+    retriever.chunk_count = len(texts)
+    retriever.avg_chunk_size = sum(len(t) for t in texts) / max(len(texts), 1)
+    return retriever
+
+
+def recall_at_k(retriever, query: str, keyword: str, use_parent_context: bool, k: int = 3) -> bool:
+    if use_parent_context:
+        docs = retriever.search_with_context(query, k=k)
+    else:
+        docs = retriever.search(query, k=k)
+    return keyword in " ".join(docs)
+
+
+def evaluate_strategy(strategy: str, backend: str, use_parent_context: bool = False) -> dict:
+    if backend == "seekdb":
+        retriever = create_seekdb_retriever(strategy, use_parent_context)
+        if retriever is None:
+            raise RuntimeError("seekdb 不可用")
+    else:
+        retriever = create_memory_retriever(strategy)
+
+    hits = sum(
+        int(recall_at_k(retriever, item["query"], item["keyword"], use_parent_context))
+        for item in EVAL_QUERIES
+    )
+    return {
+        "strategy": strategy,
+        "chunk_count": retriever.chunk_count,
+        "avg_chunk_size": retriever.avg_chunk_size,
+        "recall_at_3": hits / len(EVAL_QUERIES),
+    }
+
+
+def detect_backend() -> str:
+    try:
+        import pyseekdb
+        pyseekdb.Client()
+        return "seekdb"
+    except (ImportError, ValueError):
+        print(">>> seekdb 嵌入式模式不可用，降级为内存词项匹配检索")
+        return "memory"
+
+
+def print_runtime_notes(backend: str):
+    print(">>> 实验说明：分块策略与检索后端是两件事")
+    if backend == "memory":
+        print(">>> 当前 seekdb 不可用，仅检索阶段降级；不影响语义分块调用 Embedding API")
+    if has_siliconflow_key():
+        print(">>> 已检测到 SILICONFLOW_API_KEY，将尝试运行语义分块")
+    else:
+        print(">>> 未检测到 SILICONFLOW_API_KEY，稍后会跳过语义分块")
+
+
+def print_report(rows: list[dict], backend: str):
+    print("\n" + "=" * 72)
+    print("  D2 高级 Chunking 策略对比实验")
+    print(f"  检索后端：{'seekdb 向量检索' if backend == 'seekdb' else '内存词项匹配（降级）'}")
+    print("=" * 72)
+    print(f"  {'策略':<16} {'块数':>6} {'均长':>8} {'Recall@3':>10}")
+    print("  " + "-" * 44)
+
+    labels = {
+        "fixed": "固定 overlap",
+        "semantic": "语义分块",
+        "dynamic": "动态 overlap",
+        "parent_child": "父子 chunk",
+    }
+    for row in rows:
+        label = labels.get(row["strategy"], row["strategy"])
+        print(
+            f"  {label:<16} {row['chunk_count']:>6} "
+            f"{row['avg_chunk_size']:>7.0f}字 {row['recall_at_3']:>9.0%}"
+        )
+
+    print("\n[分析要点]")
+    print("   · 固定 overlap：实现简单，但容易在章节边界处切断语义")
+    print("   · 语义分块：按主题跳变切分，适合话题切换频繁的长文")
+    print("   · 动态 overlap：在标题/段落边界加大重叠，低成本改善边界召回")
+    print("   · 父子 chunk：子块精准检索 + 父块完整上下文，适合多跳推理")
+    print("=" * 72 + "\n")
+
+
+def main():
+    backend = detect_backend()
+    print_runtime_notes(backend)
+    results: list[dict] = []
+
+    results.append(evaluate_strategy("fixed", backend))
+    results.append(evaluate_strategy("dynamic", backend))
+    results.append(evaluate_strategy("parent_child", backend, use_parent_context=True))
+
+    try:
+        results.append(evaluate_strategy("semantic", backend))
+    except (RuntimeError, OpenAIError) as exc:
+        print(">>> 跳过语义分块：", exc)
+
+    print_report(results, backend)
+
+
+if __name__ == "__main__":
+    main()

--- a/code/D2/d2_chunking_strategies.py
+++ b/code/D2/d2_chunking_strategies.py
@@ -1,0 +1,287 @@
+"""
+D2 高级 Chunking 策略实现
+
+包含三种策略：
+  1. semantic_chunk       — 语义分块（基于句子 Embedding 的断点检测）
+  2. dynamic_overlap_chunk — 动态 overlap（边界处加大重叠）
+  3. parent_child_chunk   — 父子分块（小 chunk 检索，大 chunk 返回上下文）
+
+另提供 fixed_overlap_chunk 作为对比基线。
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ChildChunk:
+    """子 chunk：用于向量索引的细粒度片段。"""
+
+    text: str
+    parent_id: str
+    child_index: int
+
+
+@dataclass
+class ParentChunk:
+    """父 chunk：检索命中后返回给 LLM 的上下文块。"""
+
+    parent_id: str
+    text: str
+    children: list[ChildChunk] = field(default_factory=list)
+
+
+def split_sentences(text: str) -> list[str]:
+    """按中英文句号、问号、感叹号切分句子。"""
+    parts = re.split(r"(?<=[。！？.!?])\s*", text.strip())
+    return [p.strip() for p in parts if p.strip()]
+
+
+def fixed_overlap_chunk(
+    text: str,
+    chunk_size: int = 200,
+    overlap: int = 30,
+) -> list[str]:
+    """固定大小 + 固定 overlap 的基线分块策略。"""
+    chunks: list[str] = []
+    start = 0
+    while start < len(text):
+        end = start + chunk_size
+        piece = text[start:end].strip()
+        if piece:
+            chunks.append(piece)
+        start += chunk_size - overlap
+    return chunks
+
+
+def _cosine_similarity(vec_a: list[float], vec_b: list[float]) -> float:
+    dot = sum(a * b for a, b in zip(vec_a, vec_b))
+    norm_a = math.sqrt(sum(a * a for a in vec_a))
+    norm_b = math.sqrt(sum(b * b for b in vec_b))
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+def _find_semantic_breakpoints(
+    similarities: list[float],
+    percentile: float = 95.0,
+) -> set[int]:
+    """
+    在相邻句相似度序列中，找出「语义跳变」断点。
+    采用 LangChain SemanticChunker 的 percentile 思路：
+    当相似度跌幅超过第 percentile 分位时切分。
+    """
+    if len(similarities) < 2:
+        return set()
+
+    drops = [1.0 - sim for sim in similarities]
+    if max(drops) == min(drops):
+        return set()
+
+    threshold = _percentile(drops, percentile)
+
+    breakpoints: set[int] = set()
+    for idx, drop in enumerate(drops):
+        if drop >= threshold:
+            breakpoints.add(idx + 1)
+    return breakpoints
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    """用线性插值计算 percentile，避免小样本时阈值过度偏向最大值。"""
+    if not values:
+        raise ValueError("values must not be empty")
+
+    sorted_values = sorted(values)
+    bounded = min(max(percentile, 0.0), 100.0)
+    position = (len(sorted_values) - 1) * bounded / 100.0
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return sorted_values[lower]
+
+    ratio = position - lower
+    return sorted_values[lower] * (1 - ratio) + sorted_values[upper] * ratio
+
+
+def semantic_chunk(
+    text: str,
+    embed_fn,
+    percentile: float = 95.0,
+    min_chunk_chars: int = 80,
+    max_chunk_chars: int = 600,
+) -> list[str]:
+    """
+    语义分块：逐句 Embedding，在主题跳变处插入断点。
+
+    embed_fn: 接收字符串列表，返回等长向量列表的函数。
+    参考 NAACL 2025 Findings《Is Semantic Chunking Worth the Computational Cost?》
+    与 LangChain SemanticChunker 的 percentile 阈值实现。
+    """
+    sentences = split_sentences(text)
+    if not sentences:
+        return []
+    if len(sentences) == 1:
+        return sentences
+
+    embeddings = embed_fn(sentences)
+    similarities = [
+        _cosine_similarity(embeddings[i], embeddings[i + 1])
+        for i in range(len(embeddings) - 1)
+    ]
+    breakpoints = _find_semantic_breakpoints(similarities, percentile)
+
+    raw_chunks: list[str] = []
+    start = 0
+    for idx in range(1, len(sentences) + 1):
+        if idx in breakpoints or idx == len(sentences):
+            raw_chunks.append("".join(sentences[start:idx]))
+            start = idx
+
+    return _merge_small_chunks(raw_chunks, min_chunk_chars, max_chunk_chars)
+
+
+def _merge_small_chunks(
+    chunks: list[str],
+    min_chars: int,
+    max_chars: int,
+) -> list[str]:
+    """合并过小的语义块，避免碎片化。"""
+    merged: list[str] = []
+    buffer = ""
+    for chunk in chunks:
+        candidate = buffer + chunk
+        if len(candidate) < min_chars:
+            buffer = candidate
+            continue
+        if len(candidate) > max_chars and buffer:
+            merged.append(buffer)
+            buffer = chunk
+            continue
+        merged.append(candidate)
+        buffer = ""
+    if buffer:
+        if merged:
+            merged[-1] += buffer
+        else:
+            merged.append(buffer)
+    return [c.strip() for c in merged if c.strip()]
+
+
+def _detect_boundary_positions(text: str) -> set[int]:
+    """标记段落、标题、表格和代码块等需要加大 overlap 的位置。"""
+    boundaries: set[int] = set()
+    for match in re.finditer(r"\n\n+", text):
+        boundaries.add(match.start())
+    for match in re.finditer(r"(?m)^#{1,3}\s", text):
+        boundaries.add(match.start())
+    for match in re.finditer(r"(?m)^[ \t]*\|.+\|[ \t]*$", text):
+        boundaries.add(match.start())
+    for match in re.finditer(r"(?m)^```", text):
+        boundaries.add(match.start())
+    return boundaries
+
+
+def _overlap_near_boundary(
+    position: int,
+    boundaries: set[int],
+    base_overlap: int,
+    max_overlap: int,
+    window: int = 40,
+) -> int:
+    """边界附近使用更大 overlap，同质段落内使用较小 overlap。"""
+    for boundary in boundaries:
+        if abs(position - boundary) <= window:
+            return max_overlap
+    return base_overlap
+
+
+def dynamic_overlap_chunk(
+    text: str,
+    chunk_size: int = 200,
+    base_overlap: int = 20,
+    max_overlap: int = 60,
+) -> list[str]:
+    """
+    动态 overlap：在段落、标题、表格和代码块边界处加大重叠，
+    同质段落内减小重叠。
+
+    思路参考 Weaviate《Chunking Strategies for RAG》中的 Adaptive Chunking：
+    根据内容结构动态调整参数，而非全文统一 overlap。
+    """
+    if not text.strip():
+        return []
+
+    boundaries = _detect_boundary_positions(text)
+    chunks: list[str] = []
+    start = 0
+    text_len = len(text)
+
+    while start < text_len:
+        end = min(start + chunk_size, text_len)
+        piece = text[start:end].strip()
+        if piece:
+            chunks.append(piece)
+        overlap = _overlap_near_boundary(end, boundaries, base_overlap, max_overlap)
+        stride = max(chunk_size - overlap, 1)
+        start += stride
+
+    return chunks
+
+
+def parent_child_chunk(
+    text: str,
+    parent_size: int = 500,
+    child_size: int = 120,
+    child_overlap: int = 20,
+) -> list[ParentChunk]:
+    """
+    父子分块：父块保留完整上下文，子块用于精准检索。
+
+    检索时只索引子块；命中后通过 parent_id 取回父块文本给 LLM。
+    又称 small-to-big / parent-document retrieval。
+    """
+    parent_texts = fixed_overlap_chunk(text, parent_size, overlap=0)
+    parents: list[ParentChunk] = []
+
+    for parent_idx, parent_text in enumerate(parent_texts):
+        parent_id = f"parent_{parent_idx}"
+        child_texts = fixed_overlap_chunk(parent_text, child_size, child_overlap)
+        children = [
+            ChildChunk(
+                text=child_text,
+                parent_id=parent_id,
+                child_index=child_idx,
+            )
+            for child_idx, child_text in enumerate(child_texts)
+        ]
+        parents.append(
+            ParentChunk(
+                parent_id=parent_id,
+                text=parent_text,
+                children=children,
+            )
+        )
+    return parents
+
+
+def flatten_parent_child(parents: list[ParentChunk]) -> tuple[list[str], list[dict]]:
+    """将父子结构展平为 seekdb 可写入的 ids / texts / metadatas。"""
+    texts: list[str] = []
+    metadatas: list[dict] = []
+    for parent in parents:
+        for child in parent.children:
+            texts.append(child.text)
+            metadatas.append(
+                {
+                    "parent_id": parent.parent_id,
+                    "parent_text": parent.text,
+                    "child_index": child.child_index,
+                    "chunk_role": "child",
+                }
+            )
+    return texts, metadatas

--- a/code/D2/test_d2_chunking_strategies.py
+++ b/code/D2/test_d2_chunking_strategies.py
@@ -1,0 +1,55 @@
+import importlib
+import unittest
+
+from D2.d2_chunking_strategies import (
+    _detect_boundary_positions,
+    semantic_chunk,
+)
+
+
+class SemanticChunkingTests(unittest.TestCase):
+    def test_identical_embeddings_do_not_create_breakpoints(self):
+        text = "连接池需要合理配置。连接池需要持续监控。连接池需要避免泄漏。"
+
+        def embed_same(sentences):
+            return [[1.0, 0.0] for _ in sentences]
+
+        chunks = semantic_chunk(
+            text,
+            embed_same,
+            min_chunk_chars=1,
+            max_chunk_chars=1000,
+        )
+
+        self.assertEqual(chunks, [text])
+
+
+class DynamicOverlapTests(unittest.TestCase):
+    def test_detects_markdown_structure_boundaries(self):
+        text = (
+            "# 标题\n"
+            "正文段落\n\n"
+            "| 字段 | 含义 |\n"
+            "| --- | --- |\n"
+            "| code | 错误码 |\n\n"
+            "```python\n"
+            "print('hello')\n"
+            "```\n"
+        )
+
+        boundaries = _detect_boundary_positions(text)
+
+        self.assertIn(text.index("| 字段 | 含义 |"), boundaries)
+        self.assertIn(text.index("```python"), boundaries)
+        self.assertIn(text.rindex("```"), boundaries)
+
+
+class CompareScriptTests(unittest.TestCase):
+    def test_compare_script_can_be_imported_as_module(self):
+        module = importlib.import_module("D2.d2_5_chunking_compare")
+
+        self.assertTrue(hasattr(module, "main"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/requirements.txt
+++ b/code/requirements.txt
@@ -8,6 +8,9 @@ langchain-core>=0.3.29
 # 环境变量管理
 python-dotenv>=1.2.2
 
+# OpenAI 兼容 API 客户端（用于 SiliconFlow Embedding 调用）
+openai>=1.0.0
+
 # 向量数据库（可选，用于 d1_5 和 d1_6）
 pyseekdb>=1.2.0.post1
 

--- a/docs/dev/D2 课程稿：AI 应用的数据层.md
+++ b/docs/dev/D2 课程稿：AI 应用的数据层.md
@@ -8,12 +8,13 @@
 
 ```
 # ============================================================
-# 示例代码简介：从 d2_1 到 d2_4 的演进
+# 示例代码简介：从 d2_1 到 d2_5 的演进
 #
 # d2_1  数据写入      → 文档切分、向量化并写入 seekdb
 # d2_2  向量搜索      → 纯向量搜索示例
 # d2_3  混合搜索      → 向量 + 全文 + 结构化过滤
 # d2_4  对比实验      → 纯向量 vs 混合搜索结果对比
+# d2_5  分块对比      → 语义分块 / 动态 overlap / 父子 chunk 策略实验
 # ============================================================
 ```
 
@@ -90,6 +91,161 @@ def chunk_document(text: str, chunk_size: int = 500, overlap: int = 50) -> list[
 | 片段不要太长 | 500~800 字是常见范围，太长语义稀释，太短上下文不足 |
 | 保留重叠 | 相邻片段保留 50~100 字的重叠，避免关键信息落在边界 |
 | 保留元数据 | 每个片段记录来源文档、章节、更新时间等，用于后续结构化过滤 |
+
+上面这套固定大小 + 固定 overlap 的分块方式，足够帮你跑通第一个 RAG 原型。但当你把知识库从几十条 FAQ 扩展到几百页技术手册，很快就会碰到一类新问题：**检索召回对了，上下文却断了**——或者反过来，上下文完整，检索却找不到精确片段。
+
+下面三种进阶策略，就是针对这类边界场景设计的。它们不替代基础分块，而是在你确认基础方案遇到瓶颈之后的升级选项。
+
+### 进阶 Chunking 策略
+
+#### 策略一：语义分块（Semantic Chunking）
+
+固定大小分块有一个先天缺陷：它按字符数切，不管语义边界在哪。比如一段关于「错误码 E-4012」的说明，可能被切成两半：前半段进了 chunk A，后半段进了 chunk B。用户问「E-4012 怎么解决」，检索可能只命中半句话。
+
+**语义分块**的思路是：先按句子切开，给每个句子算 Embedding，再比较相邻句子的余弦相似度。当相似度出现「异常下跌」，说明话题发生了跳变，则可以在那插入断点，把前后句子分到不同 chunk。
+
+```python
+# 语义分块的核心逻辑（简化示意）
+sentences = split_sentences(long_document)
+embeddings = embed_batch(sentences)  # 每句一个向量
+
+# 计算相邻句相似度，在跌幅超过阈值处切分
+similarities = [cosine(embeddings[i], embeddings[i+1]) for i in range(len(sentences)-1)]
+breakpoints = find_breakpoints(similarities, percentile=95)  # 第 95 分位视为话题跳变
+chunks = group_sentences(sentences, breakpoints)
+```
+
+那「异常下跌」到底多大算异常？如果写死一个固定数值（比如相似度跌幅超过 0.3 就切），不同类型文档的表现会差很多——技术手册整体跌幅偏小，可能几乎不切；散文整体跌幅偏大，又可能切得太碎。更稳妥的做法是用 **percentile 阈值**：先把这篇文档里所有相邻句的相似度跌幅排个序，取第 95 分位作为切分线——只有跌幅排进全文最靠前的 5%，才判定为话题跳变。这样阈值跟着当前文档自己的分布走，而不是硬套一个全局常数。
+
+LangChain 的 `SemanticChunker`（位于 `langchain-experimental` 包）目前默认就是这套 percentile 方案，分位值 95，与上面代码示意一致。实际调参时常在 90–95 之间微调：切得太碎就调高，话题粘连就调低。这与 NAACL 2025 论文 [*Is Semantic Chunking Worth the Computational Cost?*](https://aclanthology.org/2025.findings-naacl.114.pdf) 中 breakpoint-based 语义分块器的思路一致。
+
+但代价也实实在在：入库时需要对**每个句子**调用一次 Embedding API。一篇 500 页的文档可能产生数万次 API 调用，计算成本远高于固定分块。2025–2026 年的多项 benchmark（如 [Yoke Agent 的分块评测](https://yoke-agent.digital/blog/benchmarking-chunking-strategies/)）显示：
+
+- 对 **Markdown / 技术文档** 这类结构清晰的内容，带 overlap 的递归分块往往就能拿到很好的效果，语义分块提升有限
+- 对 **话题频繁切换的散文、新闻、会议纪要**，语义分块通常能带来 2–5 个点的 Recall 提升
+- 阈值没调好会导致**过度碎片化**（平均 chunk 只有几十个 token），检索精度反而下降
+
+所以语义分块适用于结构不清晰、话题跳跃的长文，作为「基础分块效果不够好」时的优化手段。
+
+#### 策略二：动态 Overlap（Dynamic Overlap）
+
+固定 overlap 有一个隐含假设：文档每个位置的「边界风险」是一样的。实际上并非如此——章节标题、段落换行、表格前后的语义密度完全不同。在标题处切一刀，丢上下文的概率远高于段落中间。
+
+**动态 overlap** 的做法是：保持 chunk 大小基本不变，但根据内容特征**动态调整重叠量**：
+
+| 区域类型 | overlap 策略 | 原因 |
+| --- | --- | --- |
+| 同质段落内部 | 较小 overlap（如 10%） | 减少冗余，降低存储和检索噪声 |
+| 段落边界、标题行附近 | 较大 overlap（如 25–30%） | 保护跨边界的完整语义 |
+| 代码块、表格前后 | 适当加大 overlap | 避免结构信息被切断 |
+
+```python
+# 动态 overlap 示意：边界附近加大重叠
+boundaries = detect_boundaries(text)  # 段落空行、Markdown 标题等
+
+while start < len(text):
+    end = start + chunk_size
+    overlap = max_overlap if near_boundary(end, boundaries) else base_overlap
+    start += chunk_size - overlap
+```
+
+Weaviate（开源向量数据库厂商）2024 年发布的技术博客 [Chunking Strategies to Improve LLM RAG Pipeline Performance](https://weaviate.io/blog/chunking-strategies-for-rag) 将这类方法归为 **Adaptive Chunking**，即不换分块算法，只让 overlap 和步长随内容结构自适应。Yoke Agent 团队在 2026 年初做的分块策略对比实验([Benchmarking chunking strategies on a real corpus](https://yoke-agent.digital/blog/benchmarking-chunking-strategies/) )显示，在 512 token 分块上仅增加 64 token 的 overlap，Recall 就能提升约 4 个百分点，与换用更大 Embedding 模型的收益同量级，但**入库成本几乎为零**。这个实验证明了动态 overlap 的高性价比。
+
+动态 overlap 的适用的是已经有固定大小分块、不想引入 Embedding 额外开销，但边界召回率不理想的场景。这是三种策略里**性价比最高**的升级路径。
+
+#### 策略三：父子 Chunk（Parent-Child / Small-to-Big）
+
+前两种策略解决的是「怎么切」。父子 chunk 解决的是另一个矛盾：
+
+- **小块**检索精准，但塞给 LLM 时上下文不够——半句话说不清来龙去脉
+- **大块**上下文完整，但向量语义被「稀释」，检索时找不到精确片段
+
+父子 chunk 的核心思路是**把索引粒度和返回粒度解耦**：
+
+```
+原始文档
+  └── 父 chunk（500 字，存入 docstore，不建向量索引）
+        ├── 子 chunk A（120 字，建向量索引）
+        ├── 子 chunk B（120 字，建向量索引）
+        └── 子 chunk C（120 字，建向量索引）
+
+查询时：用子 chunk 做向量检索 → 命中后取 parent_id → 返回父 chunk 给 LLM
+```
+
+业界把这套做法叫做 **small-to-big retrieval**（检索用小块、生成用大块）或 **parent-document retrieval**（按父文档返回上下文）。名字不同，核心都是把“搜到什么”和“给 LLM 什么”分开。LangChain 的 `ParentDocumentRetriever`、LlamaIndex 的 `HierarchicalNodeParser` + `AutoMergingRetriever` 走的都是这条路：向量库只索引子块，父块存在独立的 docstore 里按 ID 关联，检索命中子块后再取回父块。LlamaIndex 还支持多层级合并，子块命中比例够高时才升级为更大的父块，比 LangChain 的两层方案更灵活一些。
+
+```python
+# 父子分块的数据关系
+parents = parent_child_chunk(
+    long_document,
+    parent_size=500,   # 给 LLM 的上下文单位
+    child_size=120,    # 向量检索单位
+)
+
+# 入库时只索引子块，但元数据里带上 parent_id 和 parent_text
+for parent in parents:
+    for child in parent.children:
+        vector_db.add(
+            text=child.text,
+            metadata={"parent_id": parent.parent_id, "parent_text": parent.text}
+        )
+
+# 检索时：命中子块 → 返回父块文本
+results = vector_db.query(query)
+context_for_llm = [r.metadata["parent_text"] for r in results]
+```
+
+在需要多跳推理或跨段落理解的场景（如「比较 E-4011 和 E-4012 的处理差异」），父子 chunk 的优势尤其明显：子块帮你定位到精确段落，父块给 LLM 足够的上下文做综合回答。社区 benchmark 普遍报告 **15–30%** 的答案完整度提升，代价是 LLM 侧 token 消耗随父块大小同比增加。
+
+当文档有清晰章节结构、查询需要完整上下文才能回答、且你愿意用更多 LLM token 换更好答案的生产系统的时候，可以使用考虑使用父子分块。
+
+#### 三种策略怎么选？
+
+不要试图找一个永远最优的策略，chunk 大小、overlap、分块算法都没有标准答案，得根据你自己的文档和查询试出来。下面是一张实用的决策表，可供参考：
+
+| 你的情况 | 推荐策略 | 理由 |
+| --- | --- | --- |
+| 刚起步 / 文档量小 | 固定 overlap（d2_1 默认方案） | 简单、零额外成本、足够跑通 |
+| Markdown / API 文档 / 结构清晰 | 固定 overlap + 按标题预切 | 结构信号比语义 Embedding 更可靠 |
+| 边界处经常丢上下文 | 动态 overlap | 成本最低的有效升级 |
+| 话题跳跃的无结构长文 | 语义分块 | 按语义边界切，避免硬切 |
+| 检索准但 LLM 答不全 | 父子 chunk | 小块检索 + 大块生成 |
+| 多种文档类型混合 | 按文档类型路由不同策略 | 异构语料没有 one-size-fits-all |
+
+最新的研究趋势也在朝「自适应」方向走——2026 年的 Query-Adaptive Semantic Chunking（[QASC](https://arxiv.org/abs/2605.22834)）尝试把用户查询意图融入分块阶段，在特定场景下比固定语义分块再高 8–12 个百分点。但对大多数团队来说，**先用 d2_5 跑一轮对比实验**，比追新论文更有价值。
+
+#### 动手对比：d2_5 实验
+
+课程代码 `d2_5_chunking_compare.py` 用一份多章节的数据库运维手册，对四种策略（固定 overlap 基线 + 上述三种高级策略）跑同一组查询，统计 **Recall@3**：
+
+```bash
+cd easy-data-x-ai/code
+python D2/d2_5_chunking_compare.py
+```
+
+你会看到类似下面的输出（具体数字因检索后端、Embedding 模型和阈值设置会有波动）：
+
+```
+  策略               块数     均长   Recall@3
+  --------------------------------------------
+  固定 overlap          5     186字      80%
+  动态 overlap          6     185字      80%
+  父子 chunk            9     104字      80%
+  语义分块              7     310字      80%   # 需 API Key
+```
+
+数字因 Embedding 模型和阈值设置会有波动，但实验想说明的趋势是稳定的：
+
+1. **固定 overlap 在章节边界处容易丢召回**：执行计划分析这类跨段信息被切散后，Top-3 里凑不齐完整答案
+2. **动态 overlap 用极低成本改善了边界召回**：只在标题和段落边界加大重叠，不需要额外 API 调用
+3. **语义分块让每个 chunk 更完整**：每个块围绕单一话题，均长更大、块数更少，适合话题切换频繁的手册
+4. **父子 chunk 用子块精准定位、父块补全上下文**：Recall 未必最高，但返回给 LLM 的上下文最完整，适合后续生成环节
+
+语义分块需要配置 `SILICONFLOW_API_KEY`（与课程 Embedding 示例一致）。没有 API Key 时脚本会跳过语义分块，其余三种策略仍可正常运行。
+
+另外请分清两个阶段：`seekdb` 嵌入式模式不可用时，脚本只会把**检索后端**降级为内存词项匹配，不影响语义分块阶段调用硅基流动 Embedding API。也就是说，配置了 API Key 后，即便本地没有可用的 seekdb，语义分块对比仍会执行。
+
+> **实践建议**：chunk 策略、chunk 大小、overlap 和 Embedding 模型一样，都值得你在自己的数据上对比试出来。拿 20–50 条真实 query 跑一轮 Recall@K，比看任何排行榜都靠谱。这一点和接下来将讨论的 Embedding 选型的思路完全一致。
 
 ### 向量化：把文字变成数字
 
@@ -677,7 +833,9 @@ D4 你会在同一个数据层上构建记忆系统——记忆的存储、检�
 
 1. **跑通 Notebook**：运行本模块的代码，五分钟内完成你的第一个混合查询。确认向量搜索和全文搜索各自的命中情况。
 
-2. **换成你自己的数据**：这才是关键一步。找几份你实际项目中的文档——产品文档、API 文档、内部 Wiki，什么都行。把它们存入 seekdb，然后用你日常工作中会问的问题去查询。感受一下：
+2. **跑分块对比实验**：运行 `d2_5_chunking_compare.py`，观察固定 overlap、语义分块、动态 overlap、父子 chunk 四种策略的 Recall@3 差异。如果配置了 API Key，四种策略都会跑；否则先对比后三种中的两个（动态 overlap + 父子 chunk）。
+
+3. **换成你自己的数据**：这才是关键一步。找几份你实际项目中的文档——产品文档、API 文档、内部 Wiki，什么都行。把它们存入 seekdb，然后用你日常工作中会问的问题去查询。感受一下：
    - 哪些查询是向量搜索命中、全文搜索没命中的？（语义理解的价值）
    - 哪些查询是全文搜索命中、向量搜索漏掉或排错的？（精确匹配的价值）
    - 有没有查询是两者结合才给出最佳结果的？
@@ -689,6 +847,7 @@ D4 你会在同一个数据层上构建记忆系统——记忆的存储、检�
 如果你对本期提到的概念想做进一步了解，以下是一些推荐资源：
 
 - **Embedding 模型选型与评测**：[MTEB Leaderboard](https://huggingface.co/spaces/mteb/leaderboard)，全球主流的 Embedding 模型评测基准，做 RAG 检索时重点看 Retrieval 子任务得分；[MMEB Leaderboard](https://huggingface.co/spaces/TIGER-Lab/MMEB-Leaderboard)，多模态 Embedding 评测；[硅基流动 Embedding API 文档](https://docs.siliconflow.cn/cn/api-reference/embeddings/create-embeddings)，本课程使用的 API 平台，支持 `bge-m3`、`Qwen3-Embedding` 及多模态 `Qwen3-VL-Embedding` 等模型
+- **Chunking 策略与评测**：[Weaviate · Chunking Strategies for RAG](https://weaviate.io/blog/chunking-strategies-for-rag)，涵盖固定分块、语义分块、自适应 overlap 等策略的系统梳理；[Firecrawl · Best Chunking Strategies for RAG in 2026](https://www.firecrawl.dev/blog/best-chunking-strategies-rag)，七种策略的代码示例与选型建议；[NAACL 2025 · Is Semantic Chunking Worth the Computational Cost?](https://aclanthology.org/2025.findings-naacl.114.pdf)，语义分块计算成本与效果的学术评测；[LangChain SemanticChunker API](https://api.python.langchain.com/en/latest/text_splitter/langchain_experimental.text_splitter.SemanticChunker.html)，percentile 阈值语义分块的工程实现
 - **向量搜索的原理**：[What are Vector Embeddings?](https://www.pinecone.io/learn/vector-embeddings/)，Pinecone 的入门教程，直观解释了 Embedding 和向量搜索的工作方式
 - **BM25 与全文检索**：[Understanding BM25](https://www.elastic.co/blog/practical-bm25-part-2-the-bm25-algorithm-and-its-variables)，Elastic 的技术博客，解释了全文搜索背后的经典算法
 - **RRF 融合算法**：混合搜索中如何将向量分数和全文分数合并为统一排名，Reciprocal Rank Fusion 是业界常用的方案——D3 的延伸阅读会展开这个话题


### PR DESCRIPTION
## Summary
- 认领 [#28](https://github.com/datawhalechina/easy-data-x-ai/issues/28)：在 D2 补充语义分块、动态 overlap、父子 chunk 三种高级策略说明与选型建议
- 新增配套可运行代码 `code/D2/d2_chunking_strategies.py`、`code/D2/d2_5_chunking_compare.py`，以及回归测试
- 明确 seekdb 降级只影响检索后端，不影响已配置 `SILICONFLOW_API_KEY` 时的语义分块 Embedding 调用；并补充 `openai` 依赖

## Test plan
- [x] `cd code && python -X utf8 -m unittest D2.test_d2_chunking_strategies`
- [x] `cd code && python -X utf8 D2/d2_5_chunking_compare.py`
- [x] 未配置 API Key 时确认会跳过语义分块，其余策略仍可运行
- [x] 配置 `SILICONFLOW_API_KEY` 后确认语义分块参与对比（即使 seekdb 嵌入式不可用）