### PR TITLE
fix: 修正 API Key 模板值误判

### DIFF
--- a/code/config.py
+++ b/code/config.py
@@ -38,7 +38,8 @@ class Config:
     def check_api_key(cls, key_name="SILICONFLOW_API_KEY"):
         """检查 API Key 是否已配置"""
         key = getattr(cls, key_name)
-        if key == "YOUR_API_KEY" or not key:
+        template_value = f"your_{key_name.lower()}_here"
+        if key in {"YOUR_API_KEY", template_value} or not key:
             print(f"⚠️  警告: {key_name} 未配置！")
             print(f"请在 code/.env 文件中设置 {key_name}")
             return False

--- a/code/test_config.py
+++ b/code/test_config.py
@@ -1,0 +1,38 @@
+import io
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+from config import Config
+
+
+class ConfigTests(unittest.TestCase):
+    def test_template_api_keys_are_not_configured(self):
+        template_values = {
+            "SILICONFLOW_API_KEY": "your_siliconflow_api_key_here",
+            "DASHSCOPE_API_KEY": "your_dashscope_api_key_here",
+            "OPENAI_API_KEY": "your_openai_api_key_here",
+        }
+
+        for key_name, template_value in template_values.items():
+            with self.subTest(key_name=key_name):
+                output = io.StringIO()
+
+                with patch.object(Config, key_name, template_value), redirect_stdout(output):
+                    self.assertFalse(Config.check_api_key(key_name))
+
+                self.assertIn(f"{key_name} 未配置", output.getvalue())
+
+    def test_non_template_api_key_is_configured(self):
+        with patch.object(Config, "SILICONFLOW_API_KEY", "sk-example"):
+            self.assertTrue(Config.check_api_key("SILICONFLOW_API_KEY"))
+
+    def test_missing_and_legacy_api_keys_are_not_configured(self):
+        for value in ("", "YOUR_API_KEY"):
+            with self.subTest(value=value):
+                with patch.object(Config, "SILICONFLOW_API_KEY", value), redirect_stdout(io.StringIO()):
+                    self.assertFalse(Config.check_api_key("SILICONFLOW_API_KEY"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 变更说明

- 根据环境变量名识别 `.env.example` 中对应的 `your_*_here` 模板值
- 增加配置单元测试，覆盖三个现有 API Key 模板值、空值、旧占位符和真实值

## 问题原因

`Config.check_api_key()` 原先只将空值和 `YOUR_API_KEY` 视为未配置，但 `.env.example` 使用的是更具体的 `your_siliconflow_api_key_here` 等模板值。直接复制模板而未替换时，这些值因此会被误判为有效配置。

本次认领并修复 #6，改动仅限占位符判定和回归测试，不扩展 provider 或 endpoint 配置范围。

## 验证

- 复制 `.env.example` 后，三个现有模板值均返回 `False` 并输出未配置提示
- `python -m unittest test_config D2.test_d2_chunking_strategies -v`：6 项通过
- `python -m compileall -q code`
- `npm run docs:build`
- `git diff --check`

Fixes #6
