### PR TITLE
docs: 完善 D4 补充多用户记忆隔离

### DIFF
--- a/code/D4/d4_5_multi_user_isolation.py
+++ b/code/D4/d4_5_multi_user_isolation.py
@@ -1,0 +1,392 @@
+"""
+d4_5：多用户 / 多租户记忆隔离
+
+演示：
+  1. user_id 命名空间：写入带标签，检索带过滤（查询构建阶段隔离）
+  2. 权限校验：所有者可删改，非所有者越权操作被拒绝
+  3. 显式分享：未授权不可读；授权后仅按权限放行
+
+对应课程：D4 第五部分「多用户 / 多租户记忆隔离」
+对应 Issue：datawhalechina/easy-data-x-ai#33
+
+设计对齐 PowerMem：
+  - storage/adapter.py 的 _SYSTEM_FILTER_KEYS / _build_db_filters
+  - MultiUserMemoryManager 的所有权与 PermissionError
+  - 过滤发生在查询构建阶段，而不是检索后再筛
+
+运行：
+  python d4_5_multi_user_isolation.py
+
+无需外部 API / seekdb，纯 Python 即可跑通。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+
+# ---------- 1. 数据模型 ----------
+
+@dataclass
+class MemoryRecord:
+    """一条带命名空间与权限元数据的记忆"""
+
+    id: str
+    content: str
+    user_id: str
+    agent_id: str = "tech_assistant"
+    run_id: str = "default"
+    shared_with: dict[str, list[str]] = field(default_factory=dict)
+    created_at: str = field(default_factory=lambda: datetime.now().isoformat())
+
+
+# ---------- 2. 带隔离与权限门的记忆存储 ----------
+
+class IsolatedMemoryStore:
+    """
+    模拟 PowerMem 多用户记忆隔离。
+
+    核心约定：
+      - 检索：user_id（必选）在遍历第一步就过滤
+      - 写删：先校验所有权 / 显式授权，再改数据
+    """
+
+    def __init__(self) -> None:
+        self._store: list[MemoryRecord] = []
+        self._seq = 0
+
+    def add(
+        self,
+        content: str,
+        user_id: str,
+        agent_id: str = "tech_assistant",
+        run_id: str = "default",
+    ) -> MemoryRecord:
+        """写入记忆：必须绑定 user_id 命名空间"""
+        if not user_id:
+            raise ValueError("user_id is required for multi-tenant isolation")
+
+        self._seq += 1
+        record = MemoryRecord(
+            id=f"mem_{self._seq:03d}",
+            content=content,
+            user_id=user_id,
+            agent_id=agent_id,
+            run_id=run_id,
+        )
+        self._store.append(record)
+        return record
+
+    def search(
+        self,
+        query: str,
+        user_id: str,
+        agent_id: str | None = None,
+    ) -> list[MemoryRecord]:
+        """
+        检索记忆。
+
+        关键：user_id 在查询构建阶段注入过滤条件。
+        对应 PowerMem 的 _build_db_filters，而不是“全量搜完再丢弃”。
+        显式分享且授予 read/write 的记忆，可在查询阶段一并纳入可见范围。
+        """
+        if not user_id:
+            raise ValueError("user_id is required; refusing unscoped search")
+
+        keywords = [kw for kw in query.lower().split() if kw]
+        results: list[tuple[float, MemoryRecord]] = []
+
+        for mem in self._store:
+            # 一级隔离：本人命名空间，或已被显式授予读权限
+            if mem.user_id != user_id and not self._can_read(mem, user_id):
+                continue
+            # 二级隔离（可选）：同一用户下按 agent 再切
+            if agent_id is not None and mem.agent_id != agent_id:
+                continue
+
+            score = self._relevance(mem.content, keywords)
+            if score > 0:
+                results.append((score, mem))
+
+        results.sort(key=lambda item: item[0], reverse=True)
+        return [mem for _, mem in results]
+
+    def get(self, memory_id: str) -> MemoryRecord | None:
+        for mem in self._store:
+            if mem.id == memory_id:
+                return mem
+        return None
+
+    def check_permission(
+        self,
+        memory_id: str,
+        requester_id: str,
+        permission: str,
+    ) -> bool:
+        """检查 requester 对某条记忆是否具备指定权限"""
+        mem = self.get(memory_id)
+        if mem is None:
+            return False
+        if mem.user_id == requester_id:
+            return True
+        granted = mem.shared_with.get(requester_id, [])
+        if permission in granted:
+            return True
+        # write 蕴含 read：仅授予 write 时也应可读
+        if permission == "read" and "write" in granted:
+            return True
+        return False
+
+    def share(
+        self,
+        memory_id: str,
+        owner_id: str,
+        target_user_id: str,
+        permissions: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """所有者显式分享记忆给其他用户"""
+        mem = self._require_owned(memory_id, owner_id)
+        perms = permissions or ["read"]
+        mem.shared_with[target_user_id] = list(perms)
+        return {
+            "success": True,
+            "memory_id": memory_id,
+            "shared_from": owner_id,
+            "shared_with": target_user_id,
+            "permissions": perms,
+        }
+
+    def update(
+        self,
+        memory_id: str,
+        requester_id: str,
+        new_content: str,
+    ) -> dict[str, Any]:
+        """更新记忆：所有者，或被授予 write 的用户"""
+        mem = self.get(memory_id)
+        if mem is None:
+            raise ValueError(f"Memory {memory_id} not found")
+
+        if not self.check_permission(memory_id, requester_id, "write"):
+            raise PermissionError(
+                f"User {requester_id} cannot update memory owned by {mem.user_id}"
+            )
+
+        mem.content = new_content
+        return {"success": True, "id": memory_id, "memory": new_content}
+
+    def delete(self, memory_id: str, requester_id: str) -> dict[str, Any]:
+        """删除记忆：仅所有者可以删除（对齐 MultiUserMemoryManager）"""
+        mem = self._require_owned(memory_id, requester_id)
+        self._store = [item for item in self._store if item.id != mem.id]
+        return {
+            "success": True,
+            "deleted_id": memory_id,
+            "deleted_by": requester_id,
+        }
+
+    def get_all_for_user(self, user_id: str) -> list[MemoryRecord]:
+        """调试用：列出某用户命名空间内的全部记忆"""
+        return [mem for mem in self._store if mem.user_id == user_id]
+
+    def search_without_isolation(self, query: str) -> list[MemoryRecord]:
+        """反例：去掉 user_id 过滤，演示串户风险（仅用于对比，生产禁用）"""
+        keywords = [kw for kw in query.lower().split() if kw]
+        return [
+            mem for mem in self._store
+            if self._relevance(mem.content, keywords) > 0
+        ]
+
+    def _require_owned(self, memory_id: str, requester_id: str) -> MemoryRecord:
+        mem = self.get(memory_id)
+        if mem is None:
+            raise ValueError(f"Memory {memory_id} not found")
+        if mem.user_id != requester_id:
+            raise PermissionError(
+                f"User {requester_id} does not own memory {memory_id} "
+                f"(owner={mem.user_id})"
+            )
+        return mem
+
+    @staticmethod
+    def _can_read(mem: MemoryRecord, requester_id: str) -> bool:
+        granted = mem.shared_with.get(requester_id, [])
+        return "read" in granted or "write" in granted
+
+    @staticmethod
+    def _relevance(content: str, keywords: list[str]) -> float:
+        if not keywords:
+            return 0.0
+        lower = content.lower()
+        hits = sum(1 for kw in keywords if kw in lower)
+        return hits / len(keywords)
+
+
+# ---------- 3. 演示步骤（拆成小函数，便于对照课程正文）----------
+
+def seed_users(store: IsolatedMemoryStore) -> dict[str, list[MemoryRecord]]:
+    """为 Alice / Bob 写入各自命名空间的记忆"""
+    alice_memories = [
+        store.add("Alice 是 Python 开发者，喜欢简洁回答", user_id="alice"),
+        store.add("Alice 对花生过敏，饮食建议必须避开", user_id="alice"),
+        store.add("Alice 团队前端使用 React", user_id="alice"),
+    ]
+    bob_memories = [
+        store.add("Bob 是 Java 开发者，喜欢详细解释", user_id="bob"),
+        store.add("Bob 公司技术栈以 Spring Boot 为主", user_id="bob"),
+    ]
+    return {"alice": alice_memories, "bob": bob_memories}
+
+
+def demo_namespace_isolation(store: IsolatedMemoryStore) -> None:
+    print("=" * 64)
+    print("实验 1：user_id 命名空间隔离")
+    print("=" * 64)
+
+    alice_hits = store.search("Web 框架 Python", user_id="alice")
+    bob_hits = store.search("Web 框架 Java", user_id="bob")
+
+    print("\n[Alice 检索] query='Web 框架 Python'")
+    for mem in alice_hits:
+        print(f"  - [{mem.id}] ({mem.user_id}) {mem.content}")
+    print(f"  → 共 {len(alice_hits)} 条，全部属于 alice")
+
+    print("\n[Bob 检索] query='Web 框架 Java'")
+    for mem in bob_hits:
+        print(f"  - [{mem.id}] ({mem.user_id}) {mem.content}")
+    print(f"  → 共 {len(bob_hits)} 条，全部属于 bob")
+
+    # 交叉探测：Alice 搜 Bob 领域关键词，不应命中 Bob 的记忆
+    cross = store.search("花生 过敏", user_id="bob")
+    print("\n[交叉验证] Bob 搜索「花生 过敏」（Alice 的隐私领域）")
+    if not cross:
+        print("  (无结果) → 正确：Bob 看不到 Alice 的过敏信息")
+    else:
+        print(f"  [!] 串户：Bob 看到了 {len(cross)} 条不该看见的记忆")
+        raise AssertionError("namespace isolation failed")
+
+    # 反例对比
+    leaked = store.search_without_isolation("花生 过敏")
+    print("\n[反例] 去掉 user_id 过滤后再搜「花生 过敏」")
+    for mem in leaked:
+        print(f"  - [{mem.id}] ({mem.user_id}) {mem.content}")
+    print("  → 这就是串户：敏感信息离开了命名空间边界")
+
+
+def demo_permission_guard(
+    store: IsolatedMemoryStore,
+    alice_memories: list[MemoryRecord],
+) -> None:
+    print("\n" + "=" * 64)
+    print("实验 2：权限校验（越权删除 / 合法删除）")
+    print("=" * 64)
+
+    target = alice_memories[0]
+    print(f"\n目标记忆：[{target.id}] {target.content}")
+
+    print("\n[越权] Bob 尝试删除 Alice 的记忆")
+    try:
+        store.delete(target.id, requester_id="bob")
+        print("  [!] 失败：越权删除竟然成功了")
+        raise AssertionError("permission guard failed")
+    except PermissionError as exc:
+        print(f"  PermissionError → {exc}")
+        print("  → 正确：非所有者删除被拒绝")
+
+    still_there = store.get(target.id)
+    assert still_there is not None, "memory should still exist after denied delete"
+    print(f"  记忆仍在：[{still_there.id}]")
+
+    print("\n[合法] Alice 删除自己的一条记忆")
+    result = store.delete(target.id, requester_id="alice")
+    print(f"  删除成功：{result}")
+    assert store.get(target.id) is None
+
+
+def demo_explicit_share(
+    store: IsolatedMemoryStore,
+    alice_memories: list[MemoryRecord],
+) -> None:
+    print("\n" + "=" * 64)
+    print("实验 3：显式分享 + 最小权限")
+    print("=" * 64)
+
+    # alice_memories[0] 已在实验 2 删除，取下一条
+    shared = alice_memories[1]
+    print(f"\nAlice 将 [{shared.id}] 以 read 权限分享给 Bob")
+    share_result = store.share(
+        memory_id=shared.id,
+        owner_id="alice",
+        target_user_id="bob",
+        permissions=["read"],
+    )
+    print(f"  share → {share_result}")
+
+    can_read = store.check_permission(shared.id, "bob", "read")
+    can_write = store.check_permission(shared.id, "bob", "write")
+    print(f"\n  Bob 读权限：{can_read}")
+    print(f"  Bob 写权限：{can_write}")
+    assert can_read is True
+    assert can_write is False
+
+    # 分享后：读路径在查询构建阶段放行（对齐权限表「已显式分享 → 可读/搜」）
+    bob_shared_hits = store.search("花生 过敏", user_id="bob")
+    print("\n[授权后检索] Bob 再搜「花生 过敏」")
+    for mem in bob_shared_hits:
+        print(f"  - [{mem.id}] ({mem.user_id}) {mem.content}")
+    assert any(mem.id == shared.id for mem in bob_shared_hits), (
+        "shared read should be visible in search"
+    )
+    print("  → 正确：显式分享后，Bob 可按 read 权限检索到该记忆")
+
+    print("\n[越权] Bob 仅有 read，尝试 update")
+    try:
+        store.update(shared.id, requester_id="bob", new_content="被篡改的内容")
+        raise AssertionError("write should be denied for read-only share")
+    except PermissionError as exc:
+        print(f"  PermissionError → {exc}")
+        print("  → 正确：分享 read 不等于可以改")
+
+
+def print_summary(store: IsolatedMemoryStore) -> None:
+    print("\n" + "=" * 64)
+    print("当前各用户命名空间快照")
+    print("=" * 64)
+    for user_id in ("alice", "bob"):
+        memories = store.get_all_for_user(user_id)
+        print(f"\n  [{user_id}] 共 {len(memories)} 条")
+        for mem in memories:
+            shared = (
+                f" shared={list(mem.shared_with.keys())}"
+                if mem.shared_with
+                else ""
+            )
+            print(f"    - [{mem.id}] {mem.content}{shared}")
+
+    print("\n" + "=" * 64)
+    print("总结")
+    print("  1. 多用户记忆必须用 user_id 做命名空间，检索时一并过滤")
+    print("  2. 过滤应发生在查询构建阶段，而不是检索后再丢弃")
+    print("  3. 删改要做所有权 / 授权校验，越权必须显式失败")
+    print("  4. 跨用户可见只能走显式分享，且按最小权限放行")
+    print("=" * 64)
+
+
+def main() -> None:
+    store = IsolatedMemoryStore()
+    seeded = seed_users(store)
+
+    print(">>> 已为 Alice / Bob 写入各自命名空间的记忆")
+    print(f"    Alice: {len(seeded['alice'])} 条")
+    print(f"    Bob:   {len(seeded['bob'])} 条")
+
+    demo_namespace_isolation(store)
+    demo_permission_guard(store, seeded["alice"])
+    demo_explicit_share(store, seeded["alice"])
+    print_summary(store)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/dev/D4 课程稿：Agent 开发与记忆系统.md
+++ b/docs/dev/D4 课程稿：Agent 开发与记忆系统.md
@@ -394,6 +394,142 @@ def build_prompt_with_memory(user_input):
 
 你不需要关心这些内部细节。从使用者的角度，`memory.search()` 和 `memory.add()` 就是你需要的全部 API。
 
+## 第五部分：多用户 / 多租户记忆隔离
+
+到这里，你的 Agent 已经能记住一个人了。但真实产品几乎从不上线“只有一个用户”的 Agent。
+
+想象你做了一个技术问答机器人，Alice 和 Bob 都在用。Alice 说：“我是 Python 开发者，过敏原是花生。”Bob 说：“我是 Java 开发者，喜欢详细解释。”
+
+如果记忆库里没有隔离——下一次 Bob 问“推荐个 Web 框架”，Agent 可能答：“推荐 FastAPI，顺便别碰花生。”
+
+这不是“个性化过头”，这是**数据串户**。多用户场景下，记忆系统的第一个硬要求不是“记得更聪明”，而是：**谁的记忆，只能被谁看见、被谁改。**
+
+### 问题本质：共享存储 + 独立视图
+
+工程上，多用户记忆通常共用同一套存储（同一张表、同一个向量库），靠命名空间把视图切开。PowerMem 的做法是把隔离键做成存储层的一等公民：
+
+```
+user_id  →  agent_id  →  run_id
+```
+
+- `user_id`：用户 / 租户维度（多用户隔离的主键）
+- `agent_id`：Agent 维度（同一用户下，不同 Agent 也可再隔离）
+- `run_id`：会话维度（可选，用于单次任务上下文）
+
+关键点不在存的时候写上 user_id，而在**查的时候必须带着 user_id 过滤**。PowerMem 在构建查询时就把这些字段注入过滤条件，等价于 SQL 里的：
+
+```sql
+WHERE user_id = 'alice' AND agent_id = 'tech_assistant'
+```
+
+过滤发生在数据库索引层，而不是“先全库搜一遍，再在应用代码里丢掉别人的记忆”。后者更慢，也更容易把别人的数据打进日志。
+
+### user_id 命名空间：写入带标签，检索带过滤
+
+第三部分的示例里，你已经写过 `PowerMem(user_id="developer_001")`。那一行看起来像初始化参数，本质上是在告诉记忆层：**之后所有读写，默认都落在这个命名空间里。**
+
+更显式的写法是每次调用都传入 `user_id`：
+
+```python
+from powermem import Memory, auto_config
+
+memory = Memory(config=auto_config())
+
+# Alice 的记忆写入 alice 命名空间
+memory.add(
+    "用户是 Python 开发者，喜欢简洁回答",
+    user_id="alice",
+    agent_id="tech_assistant",
+)
+
+# Bob 的记忆写入 bob 命名空间
+memory.add(
+    "用户是 Java 开发者，喜欢详细解释",
+    user_id="bob",
+    agent_id="tech_assistant",
+)
+
+# 检索时必须带上 user_id——否则就失去了隔离边界
+alice_hits = memory.search("推荐 Web 框架", user_id="alice")
+bob_hits = memory.search("推荐 Web 框架", user_id="bob")
+```
+
+`alice_hits` 里不应出现 Bob 的 Java 偏好；`bob_hits` 里也不应出现 Alice 的 Python 偏好。同一套 Agent 代码、同一套存储，靠 `user_id` 切成两个互不可见的记忆视图。
+
+多租户场景同理：把 `user_id` 理解成租户 ID（或 `tenant_id:user_id` 组合键）即可。隔离规则不变——**命名空间是边界，不是建议。**
+
+### 权限校验：隔离不够，还要拦越权操作
+
+命名空间解决的是“看不见”。但真实系统还有写操作：更新、删除、分享。如果 Bob 拿到了 Alice 某条记忆的 ID，能不能删掉它？
+
+答案必须是：**不能。** 所有权校验要发生在操作入口，而不是事后补救。
+
+PowerMem 多用户模式下的基本规则很直接：
+
+| 操作 | 本人记忆 | 他人记忆（未授权） | 他人记忆（已显式分享且授权） |
+| --- | --- | --- | --- |
+| 读 / 搜 | ✅ | ❌（命名空间过滤） | ✅（按授权权限） |
+| 更新 | ✅ | ❌ `PermissionError` | 仅当授予 write |
+| 删除 | ✅ | ❌ `PermissionError` | ❌（通常仅所有者） |
+
+用伪代码表达权限门：
+
+```python
+def delete_memory(store, memory_id, requester_id):
+    memory = store.get(memory_id)
+    if memory is None:
+        raise ValueError(f"Memory {memory_id} not found")
+
+    # 权限校验：只有所有者可以删除
+    if memory["user_id"] != requester_id:
+        raise PermissionError(
+            f"User {requester_id} cannot delete memory owned by {memory['user_id']}"
+        )
+
+    store.remove(memory_id)
+    return {"success": True, "deleted_id": memory_id}
+```
+
+注意两件事：
+
+1. **先鉴权，再改数据。** 不要先删再判断。
+2. **失败要显式。** 用 `PermissionError` / 403，而不是静默成功——静默会让调用方以为“删掉了”，实际留下脏状态。
+
+如果业务需要跨用户共享（比如客服 Agent 把一条偏好分享给销售 Agent 对应的用户视图），必须走显式授权：记录 `shared_with` 和权限列表（`read` / `write`），读路径按授权放行，写路径仍默认拒绝。
+
+### 接到 Agent 循环里长什么样
+
+回到第三部分的记忆 Agent：以前是“一个全局 memory”，现在每个请求都要绑定当前登录用户：
+
+```python
+def chat_with_memory(user_input, current_user_id):
+    # 推理前：只检索当前用户命名空间里的记忆
+    memories = memory.search(query=user_input, user_id=current_user_id, top_k=5)
+    memory_text = "\n".join([m["content"] for m in memories])
+
+    system_prompt = f"""你是一个友好的技术助手。
+
+你对这位用户有以下了解：
+{memory_text if memory_text else "暂无已知信息。"}
+"""
+
+    reply = llm_chat(system_prompt, user_input)
+
+    # 推理后：新记忆必须写入当前用户命名空间
+    memory.add(
+        messages=[
+            {"role": "user", "content": user_input},
+            {"role": "assistant", "content": reply},
+        ],
+        user_id=current_user_id,
+    )
+    return reply
+```
+
+`current_user_id` 从哪来？从你的鉴权层来——登录态、API Token、租户上下文。**绝不要让前端随便传一个 user_id 就信。** 记忆隔离的前提是：请求身份可信。
+
+配套可运行示例见 `code/D4/d4_5_multi_user_isolation.py`：用纯 Python 模拟命名空间过滤与权限门，不依赖外部 API，可以直接跑通 Alice / Bob 互不可见、越权删除被拒绝这两条核心断言。
+
 ## 我们的思考
 
 记忆系统看起来是个 AI 问题，但拆到底是个数据问题——怎么存、怎么查、怎么过期。
@@ -410,7 +546,9 @@ def build_prompt_with_memory(user_input):
 
 这个数据说明了一件反直觉的事：**把所有信息都“记住”，效果反而不如有选择地记忆。** 信息过载会干扰检索——当上下文中塞满了过时的、无关的信息，模型反而找不到真正有用的那几条。
 
-PowerMem 封装了这些最佳实践。安装 `powermem` 之后，几十行代码就能给你的 Agent 加上智能记忆——自动提取关键事实、混合检索召回相关记忆、艾宾浩斯曲线管理时效性。你不需要自己实现这些机制，但你需要理解它们背后的逻辑——因为当记忆系统表现不够好的时候，问题几乎一定出在这三个环节中的某一个。
+还有一层经常被忽略的数据边界：**多用户场景下，“记对了”之前，先要“记在正确的命名空间里”。** `user_id` 过滤和权限校验看起来像安全需求，本质上仍是数据层问题——共享存储如何切出互不串扰的视图，以及写操作如何在入口处拦住越权。没有隔离的记忆系统，个性化越强，串户风险越大。
+
+PowerMem 封装了这些最佳实践。安装 `powermem` 之后，几十行代码就能给你的 Agent 加上智能记忆——自动提取关键事实、混合检索召回相关记忆、艾宾浩斯曲线管理时效性，以及按 `user_id` 做多用户隔离。你不需要自己实现这些机制，但你需要理解它们背后的逻辑——因为当记忆系统表现不够好的时候，问题几乎一定出在“记 / 忘 / 想起 / 隔离”这几个环节中的某一个。
 
 ## 动手体验：构建你的记忆 Agent
 
@@ -499,7 +637,7 @@ while True:
 
 如果这节课的所有内容你只记住一句话，记住这句：
 
-> **给 Agent 加记忆，难的不是代码——难的是该记什么、该忘什么、该想起什么。这三个问题，本质上都是数据处理和检索的问题。**
+> **给 Agent 加记忆，难的不是代码——难的是该记什么、该忘什么、该想起什么。而一旦有了多个用户，还要先保证：该记的只记在属于他的命名空间里，别人既看不见，也改不了。**
 
 ## 课后行动
 
@@ -515,6 +653,8 @@ while True:
    然后在后续对话中，观察 Agent 是否在合适的时候自然地调用了这些信息。它有没有在你问 Web 框架时优先推荐 Python 的？有没有在你问部署方案时默认用 AWS 的？有没有记住你说过喜欢简洁、实际给出简洁的回答？
 
 3. **对比体验**：用同样的对话序列分别测试“有记忆”和“无记忆”版本，直观感受差距。
+
+4. **多用户隔离实验**：运行 `d4_5_multi_user_isolation.py`，确认 Alice / Bob 的记忆互不可见，并验证 Bob 无法删除 Alice 的记忆。然后试着故意去掉 `user_id` 过滤，观察“串户”是怎么发生的——体会为什么过滤必须发生在查询构建阶段。
 
 ## 延伸阅读
 


### PR DESCRIPTION
## Summary
- 认领 [#33](https://github.com/datawhalechina/easy-data-x-ai/issues/33)：补充 D4「多用户 / 多租户记忆隔离」
- 课程稿新增第五部分：`user_id` 命名空间过滤 + 权限校验 + 显式分享的最小权限模型
- 新增可运行示例 `code/D4/d4_5_multi_user_isolation.py`：演示 Alice/Bob 互不可见、越权删除拒绝、分享后按权限放行

## Test plan
- [x] 阅读 D4 第五部分，确认与前后文衔接自然
- [x] 运行 `python code/D4/d4_5_multi_user_isolation.py`，确认三组断言全部通过
- [x] 确认去掉 `user_id` 过滤的反例能复现串户现象
