### PR TITLE
docs: add Windows PowerShell setup examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ npm run docs:dev
 
 ### 本地运行示例代码
 
+macOS/Linux：
+
 ```bash
 cd code
 
@@ -129,6 +131,17 @@ cp .env.example .env
 # 运行示例
 cd D1
 python3 d1_1_base.py
+```
+
+Windows PowerShell：
+
+```powershell
+cd code
+python -m pip install -r requirements.txt
+Copy-Item .env.example .env
+# 编辑 .env 文件，填写你的 API Key
+cd D1
+python d1_1_base.py
 ```
 
 示例代码会优先读取 `code/.env`；如果该文件不存在，也支持从父目录向上查找 `.env`（例如仓库根目录 `.env`）。已有系统环境变量不会被 `.env` 覆盖。

--- a/code/README.md
+++ b/code/README.md
@@ -55,6 +55,8 @@ DASHSCOPE_API_KEY=your_dashscope_api_key_here
 
 ### 3. 运行示例
 
+macOS/Linux：
+
 ```bash
 cd D1
 python3 d1_1_base.py

--- a/code/README.md
+++ b/code/README.md
@@ -29,10 +29,16 @@ pip install --upgrade -r requirements.txt
 
 ### 2. 配置 API Key
 
-复制环境变量示例文件：
+macOS/Linux：
 
 ```bash
 cp .env.example .env
+```
+
+Windows PowerShell：
+
+```powershell
+Copy-Item .env.example .env
 ```
 
 编辑 `.env` 文件，填写你的 API Key：
@@ -50,6 +56,13 @@ DASHSCOPE_API_KEY=your_dashscope_api_key_here
 ### 3. 运行示例
 
 ```bash
+cd D1
+python3 d1_1_base.py
+```
+
+Windows PowerShell：
+
+```powershell
 cd D1
 python d1_1_base.py
 ```


### PR DESCRIPTION
## Summary

- 在根 README 增加 Windows PowerShell 安装、配置和运行示例
- 在 `code/README.md` 增加 `Copy-Item` 与 `python` 示例
- 明确区分 macOS/Linux 与 Windows PowerShell 命令

## Validation

- Python 3.11.9：`compileall` 通过
- `npm ci` 通过
- VitePress 文档构建通过
- 文档命令与平台标签静态检查通过
- `git diff --check` 通过

说明：当前环境为 macOS，未在 Windows 实机运行 PowerShell 命令。

Closes #9
