### PR TITLE
chore: pin VitePress version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       },
       "devDependencies": {
         "markdown-it-mathjax3": "^4.3.2",
-        "vitepress": "^2.0.0-alpha.15"
+        "vitepress": "2.0.0-alpha.15"
       }
     },
     "node_modules/@ai-sdk/gateway": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "markdown-it-mathjax3": "^4.3.2",
-    "vitepress": "^2.0.0-alpha.15"
+    "vitepress": "2.0.0-alpha.15"
   },
   "scripts": {
     "docs:dev": "vitepress dev docs",


### PR DESCRIPTION
## Summary

- 将 `vitepress` 从 `^2.0.0-alpha.15` 固定为 `2.0.0-alpha.15`
- 同步更新 lockfile 的根包声明
- 保持实际解析版本和依赖图不变

## Validation

- `npm ci` 通过
- `npm ls vitepress` 确认解析为 `2.0.0-alpha.15`
- VitePress 文档构建通过
- Python 3.11.9：`compileall` 通过
- `git diff --check` 通过

Closes #12
