### PR TITLE
test: add import path regression coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,5 +45,8 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Test D1 import paths
+        run: python -m unittest discover -s code -p 'test_example_import_paths.py' -v
+
       - name: Compile Python examples
         run: python -m compileall code

--- a/code/test_example_import_paths.py
+++ b/code/test_example_import_paths.py
@@ -1,0 +1,59 @@
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class ExampleImportPathTests(unittest.TestCase):
+    def setUp(self):
+        self.example_path = Path(__file__).resolve().parent / "D1" / "d1_1_base.py"
+
+    def test_example_runs_from_repository_root(self):
+        self._assert_example_runs(Path(__file__).resolve().parents[1])
+
+    def test_example_runs_from_unrelated_directory(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self._assert_example_runs(Path(temp_dir))
+
+    def _assert_example_runs(self, cwd):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            stub_dir = Path(temp_dir)
+            langchain_dir = stub_dir / "langchain"
+            langchain_dir.mkdir()
+            (langchain_dir / "__init__.py").write_text("", encoding="utf-8")
+            (langchain_dir / "chat_models.py").write_text(
+                """
+class FakeResponse:
+    content = \"stub answer\"
+
+
+class FakeModel:
+    def invoke(self, messages):
+        return FakeResponse()
+
+
+def init_chat_model(*args, **kwargs):
+    return FakeModel()
+""".lstrip(),
+                encoding="utf-8",
+            )
+            environment = os.environ.copy()
+            environment["PYTHONPATH"] = str(stub_dir)
+            result = subprocess.run(
+                [sys.executable, str(self.example_path)],
+                cwd=cwd,
+                env=environment,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("stub answer", result.stdout)
+        self.assertNotIn("No module named 'config'", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- 为示例脚本的导入路径增加回归测试
- 覆盖从仓库根目录和无关工作目录启动两种场景
- 将回归测试接入现有 Python 3.11 CI

说明：生产代码中的路径修复已由 #59 提交，本 PR 补齐自动化回归保障。

## Validation

- Python 3.11.9：回归测试 2/2 通过
- Python 3.11.9：`compileall` 通过
- `npm ci` 通过
- VitePress 文档构建通过
- Workflow YAML 解析通过
- `git diff --check` 通过

Closes #8
