### PR TITLE
fix: 加固 code 示例与仓库级测试

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Build docs
         run: npm run docs:build
 
-  python-compile:
-    name: Python Syntax Check
+  python-tests:
+    name: Python Tests
     runs-on: ubuntu-latest
 
     steps:
@@ -45,5 +45,13 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r code/requirements-test.txt
+
+      - name: Run Python tests
+        run: python code/run_tests.py
+
       - name: Compile Python examples
-        run: python -m compileall code
+        run: python -m compileall -q code

--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,9 @@ __pycache__/
 # seekdb / memory 本地数据库（运行示例代码时生成）
 code/**/seekdb.db/
 code/**/memory.db/
+code/**/memory_persistent.db/
+code/D3/d3_seekdb/
 code/**/skills.seekdb/
 code/**/skills.db
+/memory.db/
+/memory_persistent.db/

--- a/code/D2/d2_1_ingest.py
+++ b/code/D2/d2_1_ingest.py
@@ -26,6 +26,11 @@ def chunk_document(text: str, chunk_size: int = 200, overlap: int = 30) -> list[
     将长文档切分为带重叠的小片段。
     overlap（重叠）确保片段边界处的语义不丢失。
     """
+    if chunk_size <= 0:
+        raise ValueError("chunk_size 必须大于 0")
+    if overlap < 0 or overlap >= chunk_size:
+        raise ValueError("overlap 必须大于等于 0 且小于 chunk_size")
+
     chunks = []
     start = 0
     while start < len(text):

--- a/code/D2/d2_3_hybrid_search.py
+++ b/code/D2/d2_3_hybrid_search.py
@@ -89,7 +89,11 @@ print("【场景三：混合搜索 + 结构化过滤——只搜 4.2 版本的�
 print("查询：'性能优化'，限定 version=4.2\n")
 
 results = collection.hybrid_search(
-    query={"n_results": 5},                                              # 全文搜索（无关键词过滤）
+    query={
+        "where_document": {"$contains": "性能优化"},
+        "where": {"version": "4.2"},
+        "n_results": 5,
+    },  # 全文搜索 + 版本过滤
     knn={"query_texts": ["性能优化"], "where": {"version": "4.2"}, "n_results": 5},  # 向量搜索 + 版本过滤
     rank={"rrf": {}},
     n_results=3,

--- a/code/D2/d2_5_chunking_compare.py
+++ b/code/D2/d2_5_chunking_compare.py
@@ -159,13 +159,18 @@ class SeekdbRetriever:
         return contexts
 
 
+def _get_siliconflow_api_key() -> str:
+    """返回去除首尾空白后的 SiliconFlow API Key。"""
+    return Config.SILICONFLOW_API_KEY.strip()
+
+
 def build_embed_fn():
-    api_key = Config.SILICONFLOW_API_KEY
-    if not api_key or api_key == "YOUR_API_KEY":
+    api_key = _get_siliconflow_api_key()
+    if api_key in {"", "YOUR_API_KEY", "your_siliconflow_api_key_here"}:
         raise RuntimeError("语义分块需要 SILICONFLOW_API_KEY，请在 code/.env 中配置")
 
     client = OpenAI(
-        api_key=Config.SILICONFLOW_API_KEY,
+        api_key=api_key,
         base_url=Config.SILICONFLOW_BASE_URL,
     )
 
@@ -177,8 +182,8 @@ def build_embed_fn():
 
 
 def has_siliconflow_key() -> bool:
-    api_key = Config.SILICONFLOW_API_KEY
-    return bool(api_key and api_key != "YOUR_API_KEY")
+    api_key = _get_siliconflow_api_key()
+    return api_key not in {"", "YOUR_API_KEY", "your_siliconflow_api_key_here"}
 
 
 def prepare_strategy_chunks(strategy: str) -> tuple[list[str], list[dict]]:

--- a/code/D2/d2_chunking_strategies.py
+++ b/code/D2/d2_chunking_strategies.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import math
 import re
 from dataclasses import dataclass, field
+from numbers import Real
 
 
 @dataclass
@@ -46,6 +47,7 @@ def fixed_overlap_chunk(
     overlap: int = 30,
 ) -> list[str]:
     """固定大小 + 固定 overlap 的基线分块策略。"""
+    _validate_fixed_chunk_parameters(chunk_size, overlap)
     chunks: list[str] = []
     start = 0
     while start < len(text):
@@ -55,6 +57,14 @@ def fixed_overlap_chunk(
             chunks.append(piece)
         start += chunk_size - overlap
     return chunks
+
+
+def _validate_fixed_chunk_parameters(chunk_size: int, overlap: int) -> None:
+    """校验固定分块参数，确保循环步长始终为正数。"""
+    if chunk_size <= 0:
+        raise ValueError("chunk_size 必须大于 0")
+    if overlap < 0 or overlap >= chunk_size:
+        raise ValueError("overlap 必须大于等于 0 且小于 chunk_size")
 
 
 def _cosine_similarity(vec_a: list[float], vec_b: list[float]) -> float:
@@ -122,27 +132,65 @@ def semantic_chunk(
     参考 NAACL 2025 Findings《Is Semantic Chunking Worth the Computational Cost?》
     与 LangChain SemanticChunker 的 percentile 阈值实现。
     """
+    if (
+        isinstance(percentile, bool)
+        or not isinstance(percentile, Real)
+        or not math.isfinite(percentile)
+        or not 0 <= percentile <= 100
+    ):
+        raise ValueError("percentile 必须是 0 到 100 之间的有限数值")
+    if min_chunk_chars <= 0:
+        raise ValueError("min_chunk_chars 必须大于 0")
+    if max_chunk_chars <= 0:
+        raise ValueError("max_chunk_chars 必须大于 0")
+    if min_chunk_chars > max_chunk_chars:
+        raise ValueError("min_chunk_chars 不能大于 max_chunk_chars")
+
     sentences = split_sentences(text)
     if not sentences:
         return []
+
     if len(sentences) == 1:
-        return sentences
+        raw_chunks = sentences
+    else:
+        embeddings = list(embed_fn(sentences))
+        _validate_embeddings(embeddings, len(sentences))
+        similarities = [
+            _cosine_similarity(embeddings[i], embeddings[i + 1])
+            for i in range(len(embeddings) - 1)
+        ]
+        breakpoints = _find_semantic_breakpoints(similarities, percentile)
 
-    embeddings = embed_fn(sentences)
-    similarities = [
-        _cosine_similarity(embeddings[i], embeddings[i + 1])
-        for i in range(len(embeddings) - 1)
-    ]
-    breakpoints = _find_semantic_breakpoints(similarities, percentile)
-
-    raw_chunks: list[str] = []
-    start = 0
-    for idx in range(1, len(sentences) + 1):
-        if idx in breakpoints or idx == len(sentences):
-            raw_chunks.append("".join(sentences[start:idx]))
-            start = idx
+        raw_chunks = []
+        start = 0
+        for idx in range(1, len(sentences) + 1):
+            if idx in breakpoints or idx == len(sentences):
+                raw_chunks.append("".join(sentences[start:idx]))
+                start = idx
 
     return _merge_small_chunks(raw_chunks, min_chunk_chars, max_chunk_chars)
+
+
+def _validate_embeddings(embeddings: list[list[float]], expected_count: int) -> None:
+    """校验 Embedding 数量、维度及数值有效性。"""
+    if len(embeddings) != expected_count:
+        raise ValueError(
+            f"Embedding 数量应为 {expected_count}，实际为 {len(embeddings)}"
+        )
+
+    dimension = len(embeddings[0]) if embeddings else 0
+    if dimension == 0:
+        raise ValueError("Embedding 向量不能为空")
+
+    for vector in embeddings:
+        if len(vector) != dimension:
+            raise ValueError("Embedding 向量维度必须一致")
+        try:
+            finite = all(math.isfinite(value) for value in vector)
+        except TypeError as exc:
+            raise ValueError("Embedding 向量必须只包含数值") from exc
+        if not finite:
+            raise ValueError("Embedding 向量必须只包含有限数值")
 
 
 def _merge_small_chunks(
@@ -150,22 +198,27 @@ def _merge_small_chunks(
     min_chars: int,
     max_chars: int,
 ) -> list[str]:
-    """合并过小的语义块，避免碎片化。"""
+    """合并过小的语义块，并保证每个块不超过最大长度。"""
+    bounded_chunks = [
+        chunk[start:start + max_chars]
+        for chunk in chunks
+        for start in range(0, len(chunk), max_chars)
+    ]
     merged: list[str] = []
     buffer = ""
-    for chunk in chunks:
+    for chunk in bounded_chunks:
         candidate = buffer + chunk
-        if len(candidate) < min_chars:
+        if len(candidate) <= max_chars and len(candidate) < min_chars:
             buffer = candidate
             continue
-        if len(candidate) > max_chars and buffer:
+        if len(candidate) > max_chars:
             merged.append(buffer)
             buffer = chunk
             continue
         merged.append(candidate)
         buffer = ""
     if buffer:
-        if merged:
+        if merged and len(merged[-1]) + len(buffer) <= max_chars:
             merged[-1] += buffer
         else:
             merged.append(buffer)
@@ -213,6 +266,15 @@ def dynamic_overlap_chunk(
     思路参考 Weaviate《Chunking Strategies for RAG》中的 Adaptive Chunking：
     根据内容结构动态调整参数，而非全文统一 overlap。
     """
+    if chunk_size <= 0:
+        raise ValueError("chunk_size 必须大于 0")
+    if base_overlap < 0 or max_overlap < 0:
+        raise ValueError("overlap 必须大于等于 0")
+    if base_overlap > max_overlap:
+        raise ValueError("base_overlap 不能大于 max_overlap")
+    if max_overlap >= chunk_size:
+        raise ValueError("max_overlap 必须小于 chunk_size")
+
     if not text.strip():
         return []
 
@@ -245,6 +307,9 @@ def parent_child_chunk(
     检索时只索引子块；命中后通过 parent_id 取回父块文本给 LLM。
     又称 small-to-big / parent-document retrieval。
     """
+    _validate_fixed_chunk_parameters(parent_size, 0)
+    _validate_fixed_chunk_parameters(child_size, child_overlap)
+
     parent_texts = fixed_overlap_chunk(text, parent_size, overlap=0)
     parents: list[ParentChunk] = []
 

--- a/code/D2/test_d2_chunking_strategies.py
+++ b/code/D2/test_d2_chunking_strategies.py
@@ -1,13 +1,49 @@
 import importlib
+import math
 import unittest
+from unittest.mock import patch
 
 from D2.d2_chunking_strategies import (
     _detect_boundary_positions,
+    dynamic_overlap_chunk,
+    fixed_overlap_chunk,
+    parent_child_chunk,
     semantic_chunk,
 )
 
 
+class FixedOverlapValidationTests(unittest.TestCase):
+    def test_rejects_non_positive_size_and_invalid_overlap(self):
+        invalid_parameters = (
+            {"chunk_size": 0, "overlap": 0},
+            {"chunk_size": -1, "overlap": 0},
+            {"chunk_size": 3, "overlap": -1},
+            {"chunk_size": 3, "overlap": 3},
+            {"chunk_size": 3, "overlap": 4},
+        )
+
+        for parameters in invalid_parameters:
+            with self.subTest(parameters=parameters):
+                with self.assertRaises(ValueError):
+                    fixed_overlap_chunk("", **parameters)
+
+
 class SemanticChunkingTests(unittest.TestCase):
+    def test_rejects_non_numeric_non_finite_or_out_of_range_percentile(self):
+        text = "第一句。第二句。"
+        invalid_values = (None, "95", math.nan, math.inf, -1, 101)
+
+        for percentile in invalid_values:
+            with self.subTest(percentile=percentile):
+                with self.assertRaisesRegex(ValueError, "percentile"):
+                    semantic_chunk(
+                        text,
+                        lambda _sentences: [[1.0, 0.0], [0.0, 1.0]],
+                        percentile=percentile,
+                        min_chunk_chars=1,
+                        max_chunk_chars=100,
+                    )
+
     def test_identical_embeddings_do_not_create_breakpoints(self):
         text = "连接池需要合理配置。连接池需要持续监控。连接池需要避免泄漏。"
 
@@ -22,6 +58,55 @@ class SemanticChunkingTests(unittest.TestCase):
         )
 
         self.assertEqual(chunks, [text])
+
+    def test_rejects_invalid_minimum_and_maximum_lengths(self):
+        invalid_parameters = (
+            {"min_chunk_chars": 0, "max_chunk_chars": 10},
+            {"min_chunk_chars": 1, "max_chunk_chars": 0},
+            {"min_chunk_chars": 11, "max_chunk_chars": 10},
+        )
+
+        for parameters in invalid_parameters:
+            with self.subTest(parameters=parameters):
+                with self.assertRaises(ValueError):
+                    semantic_chunk("", lambda _sentences: [], **parameters)
+
+    def test_rejects_embedding_count_mismatch(self):
+        text = "第一句。第二句。第三句。"
+
+        for embeddings in (
+            [[1.0, 0.0]],
+            [[1.0, 0.0]] * 4,
+        ):
+            with self.subTest(embedding_count=len(embeddings)):
+                with self.assertRaisesRegex(ValueError, "数量"):
+                    semantic_chunk(text, lambda _sentences, result=embeddings: result)
+
+    def test_rejects_empty_mismatched_and_non_finite_embeddings(self):
+        text = "第一句。第二句。"
+        invalid_embeddings = (
+            [[], []],
+            [[1.0, 0.0], [1.0]],
+            [[1.0, math.nan], [1.0, 0.0]],
+            [[1.0, math.inf], [1.0, 0.0]],
+        )
+
+        for embeddings in invalid_embeddings:
+            with self.subTest(embeddings=embeddings):
+                with self.assertRaisesRegex(ValueError, "向量"):
+                    semantic_chunk(text, lambda _sentences, result=embeddings: result)
+
+    def test_never_returns_chunks_larger_than_maximum(self):
+        text = "甲" * 250
+
+        chunks = semantic_chunk(
+            text,
+            lambda _sentences: [],
+            min_chunk_chars=1,
+            max_chunk_chars=100,
+        )
+
+        self.assertEqual(chunks, ["甲" * 100, "甲" * 100, "甲" * 50])
 
 
 class DynamicOverlapTests(unittest.TestCase):
@@ -43,12 +128,52 @@ class DynamicOverlapTests(unittest.TestCase):
         self.assertIn(text.index("```python"), boundaries)
         self.assertIn(text.rindex("```"), boundaries)
 
+    def test_rejects_invalid_sizes_and_overlaps(self):
+        invalid_parameters = (
+            {"chunk_size": 0, "base_overlap": 0, "max_overlap": 0},
+            {"chunk_size": 10, "base_overlap": -1, "max_overlap": 2},
+            {"chunk_size": 10, "base_overlap": 3, "max_overlap": 2},
+            {"chunk_size": 10, "base_overlap": 2, "max_overlap": 10},
+        )
+
+        for parameters in invalid_parameters:
+            with self.subTest(parameters=parameters):
+                with self.assertRaises(ValueError):
+                    dynamic_overlap_chunk("", **parameters)
+
+
+class ParentChildValidationTests(unittest.TestCase):
+    def test_rejects_invalid_sizes_and_child_overlap(self):
+        invalid_parameters = (
+            {"parent_size": 0, "child_size": 10, "child_overlap": 0},
+            {"parent_size": 10, "child_size": 0, "child_overlap": 0},
+            {"parent_size": 10, "child_size": 5, "child_overlap": -1},
+            {"parent_size": 10, "child_size": 5, "child_overlap": 5},
+        )
+
+        for parameters in invalid_parameters:
+            with self.subTest(parameters=parameters):
+                with self.assertRaises(ValueError):
+                    parent_child_chunk("", **parameters)
+
 
 class CompareScriptTests(unittest.TestCase):
     def test_compare_script_can_be_imported_as_module(self):
         module = importlib.import_module("D2.d2_5_chunking_compare")
 
         self.assertTrue(hasattr(module, "main"))
+
+    def test_blank_and_template_api_keys_are_not_available(self):
+        module = importlib.import_module("D2.d2_5_chunking_compare")
+
+        for api_key in (
+            "   ",
+            "  YOUR_API_KEY  ",
+            "  your_siliconflow_api_key_here  ",
+        ):
+            with self.subTest(api_key=api_key):
+                with patch.object(module.Config, "SILICONFLOW_API_KEY", api_key):
+                    self.assertFalse(module.has_siliconflow_key())
 
 
 if __name__ == "__main__":

--- a/code/D2/test_d2_hybrid_search.py
+++ b/code/D2/test_d2_hybrid_search.py
@@ -1,0 +1,72 @@
+import io
+import runpy
+import sys
+import types
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+
+class FakeCollection:
+    def __init__(self):
+        self.hybrid_calls = []
+
+    def count(self):
+        return 0
+
+    def hybrid_search(self, **kwargs):
+        self.hybrid_calls.append(kwargs)
+        return {
+            "documents": [[]],
+            "distances": [[]],
+            "metadatas": [[]],
+        }
+
+
+class FakeDatabase:
+    def __init__(self, collection):
+        self.collection = collection
+
+    def has_collection(self, _name):
+        return True
+
+    def get_collection(self, _name):
+        return self.collection
+
+
+class HybridSearchExampleTests(unittest.TestCase):
+    def test_filtered_hybrid_search_filters_both_search_branches(self):
+        collection = FakeCollection()
+        fake_pyseekdb = types.ModuleType("pyseekdb")
+        fake_pyseekdb.Client = lambda: FakeDatabase(collection)
+        script_path = Path(__file__).with_name("d2_3_hybrid_search.py")
+
+        with (
+            patch.dict(sys.modules, {"pyseekdb": fake_pyseekdb}),
+            redirect_stdout(io.StringIO()),
+        ):
+            runpy.run_path(script_path)
+
+        filtered_call = collection.hybrid_calls[2]
+        self.assertEqual(
+            filtered_call,
+            {
+                "query": {
+                    "where_document": {"$contains": "性能优化"},
+                    "where": {"version": "4.2"},
+                    "n_results": 5,
+                },
+                "knn": {
+                    "query_texts": ["性能优化"],
+                    "where": {"version": "4.2"},
+                    "n_results": 5,
+                },
+                "rank": {"rrf": {}},
+                "n_results": 3,
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/D2/test_d2_ingest.py
+++ b/code/D2/test_d2_ingest.py
@@ -1,0 +1,58 @@
+import io
+import runpy
+import sys
+import types
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+
+class FakeCollection:
+    def add(self, **_kwargs):
+        return None
+
+    def count(self):
+        return 0
+
+
+class FakeDatabase:
+    def has_collection(self, _name):
+        return False
+
+    def create_collection(self, name):
+        return FakeCollection()
+
+
+class IngestChunkValidationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        fake_pyseekdb = types.ModuleType("pyseekdb")
+        fake_pyseekdb.Client = FakeDatabase
+        script_path = Path(__file__).with_name("d2_1_ingest.py")
+
+        with (
+            patch.dict(sys.modules, {"pyseekdb": fake_pyseekdb}),
+            redirect_stdout(io.StringIO()),
+        ):
+            namespace = runpy.run_path(script_path)
+
+        cls.chunk_document = staticmethod(namespace["chunk_document"])
+
+    def test_rejects_non_positive_size_and_invalid_overlap(self):
+        invalid_parameters = (
+            {"chunk_size": 0, "overlap": 0},
+            {"chunk_size": -1, "overlap": 0},
+            {"chunk_size": 3, "overlap": -1},
+            {"chunk_size": 3, "overlap": 3},
+            {"chunk_size": 3, "overlap": 4},
+        )
+
+        for parameters in invalid_parameters:
+            with self.subTest(parameters=parameters):
+                with self.assertRaises(ValueError):
+                    self.chunk_document("", **parameters)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/D3/d3_1_ingest.py
+++ b/code/D3/d3_1_ingest.py
@@ -1,4 +1,5 @@
 import sys
+from collections import Counter
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -103,34 +104,45 @@ knowledge_chunks = [
 
 # ---------- 2. 初始化 seekdb 并写入数据 ----------
 
-print(">>> 正在初始化 seekdb...")
-db = pyseekdb.Client()
-collection_name = "d3_product_kb"
+DATABASE_PATH = Path(__file__).resolve().parent / "d3_seekdb"
+COLLECTION_NAME = "d3_product_kb"
 
-# 如果已存在则先删除，确保每次运行都是干净的
-if db.has_collection(collection_name):
-    db.delete_collection(collection_name)
-    print(f">>> 已删除旧集合：{collection_name}")
 
-collection = db.create_collection(name=collection_name)
-print(f">>> 集合创建成功：{collection_name}\n")
+def create_db_client():
+    """创建路径稳定的 seekdb 客户端。"""
+    return pyseekdb.Client(path=str(DATABASE_PATH))
 
-# 批量写入
-collection.add(
-    ids=[chunk["id"] for chunk in knowledge_chunks],
-    documents=[chunk["content"] for chunk in knowledge_chunks],
-    metadatas=[{"doc_type": chunk["doc_type"], "version": chunk["version"]} for chunk in knowledge_chunks],
-)
 
-print(f">>> 已写入 {collection.count()} 个知识片段")
-print()
+def build_knowledge_base(database):
+    """复用固定集合，并用 upsert 幂等写入知识片段。"""
+    collection = database.get_or_create_collection(name=COLLECTION_NAME)
+    collection.upsert(
+        ids=[chunk["id"] for chunk in knowledge_chunks],
+        documents=[chunk["content"] for chunk in knowledge_chunks],
+        metadatas=[
+            {"doc_type": chunk["doc_type"], "version": chunk["version"]}
+            for chunk in knowledge_chunks
+        ],
+    )
+    return collection
 
-# 展示写入的数据分布
-from collections import Counter
-type_counts = Counter(chunk["doc_type"] for chunk in knowledge_chunks)
-print(">>> 知识库内容分布：")
-for doc_type, count in type_counts.items():
-    print(f"    {doc_type}: {count} 条")
 
-print()
-print(">>> d3_1 完成！知识库已就绪，可运行 d3_2 / d3_3 继续体验。")
+def main():
+    print(">>> 正在初始化 seekdb...")
+    with create_db_client() as database:
+        collection = build_knowledge_base(database)
+        print(f">>> 集合已就绪：{COLLECTION_NAME}\n")
+        print(f">>> 已写入或更新 {collection.count()} 个知识片段")
+        print()
+
+        type_counts = Counter(chunk["doc_type"] for chunk in knowledge_chunks)
+        print(">>> 知识库内容分布：")
+        for doc_type, count in type_counts.items():
+            print(f"    {doc_type}: {count} 条")
+
+    print()
+    print(">>> d3_1 完成！知识库已就绪，可运行 d3_2 / d3_3 继续体验。")
+
+
+if __name__ == "__main__":
+    main()

--- a/code/D3/d3_2_agentic_rag.py
+++ b/code/D3/d3_2_agentic_rag.py
@@ -1,10 +1,11 @@
 import sys
+import json
+import re
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from config import Config
 import pyseekdb
-import json
 from openai import OpenAI
 
 # ============================================================
@@ -21,25 +22,10 @@ from openai import OpenAI
 # ============================================================
 
 
-# ---------- 0. 连接知识库 ----------
+# ---------- 0. 运行配置 ----------
 
-db = pyseekdb.Client()
-collection_name = "d3_product_kb"
-
-if not db.has_collection(collection_name):
-    print("❌ 未找到知识库，请先运行 d3_1_ingest.py 写入数据")
-    exit(1)
-
-collection = db.get_collection(collection_name)
-print(f">>> 已连接知识库：{collection_name}，共 {collection.count()} 条文档\n")
-
-
-# ---------- 1. 初始化 LLM 客户端 ----------
-
-client = OpenAI(
-    api_key=Config.SILICONFLOW_API_KEY,
-    base_url=Config.SILICONFLOW_BASE_URL,
-)
+DATABASE_PATH = Path(__file__).resolve().parent / "d3_seekdb"
+COLLECTION_NAME = "d3_product_kb"
 MODEL = "deepseek-ai/DeepSeek-V3"
 
 
@@ -72,11 +58,56 @@ tools = [
 
 # ---------- 3. 工具执行函数 ----------
 
-def execute_search(query: str) -> str:
+def create_db_client():
+    """创建路径稳定的 seekdb 客户端。"""
+    return pyseekdb.Client(path=str(DATABASE_PATH))
+
+
+def create_model_client():
+    """创建 OpenAI 兼容模型客户端。"""
+    return OpenAI(
+        api_key=Config.SILICONFLOW_API_KEY,
+        base_url=Config.SILICONFLOW_BASE_URL,
+    )
+
+
+def extract_search_keyword(query: str) -> str:
+    """优先提取错误码、季度、版本号和函数名等精确标识符。"""
+    error_code = re.search(r"\bE-\d+\b", query, flags=re.IGNORECASE)
+    if error_code:
+        return error_code.group(0).upper()
+
+    quarter = re.search(r"(?:20\d{2}年?)?(Q[1-4])", query, flags=re.IGNORECASE)
+    if quarter:
+        return quarter.group(1).upper()
+
+    version = re.search(r"\bOB-\d+(?:\.\d+)+\b", query, flags=re.IGNORECASE)
+    if version:
+        return version.group(0)
+
+    function_name = re.search(r"\b[A-Z][A-Z0-9_]{2,}\b", query)
+    if function_name:
+        return function_name.group(0)
+
+    return query.strip()
+
+
+def execute_search(query: str, target_collection=None) -> str:
     """调用 seekdb 混合检索，返回格式化的检索结果"""
+    if target_collection is None:
+        with create_db_client() as database:
+            if not database.has_collection(COLLECTION_NAME):
+                return "知识库尚未初始化，请先运行 d3_1_ingest.py。"
+            collection = database.get_collection(COLLECTION_NAME)
+            return execute_search(query, collection)
+
+    keyword = extract_search_keyword(query)
     # 使用混合检索：向量语义 + 全文关键词
-    results = collection.hybrid_search(
-        query={"where_document": {"$contains": query.split()[0] if query.split() else query}, "n_results": 5},
+    results = target_collection.hybrid_search(
+        query={
+            "where_document": {"$contains": keyword},
+            "n_results": 5,
+        },
         knn={"query_texts": [query], "n_results": 5},
         rank={"rrf": {}},
         n_results=3,
@@ -92,13 +123,40 @@ def execute_search(query: str) -> str:
     return "\n\n".join(formatted)
 
 
-# ---------- 4. Agentic RAG 主函数 ----------
+def _tool_result(tool_call, search_fn) -> str:
+    """安全解析并执行单个工具调用。"""
+    function = getattr(tool_call, "function", None)
+    function_name = getattr(function, "name", "")
+    if function_name != "search_knowledge_base":
+        return f"未知工具：{function_name or '未提供名称'}"
 
-def ask_agent(question: str) -> str:
-    """
-    Agentic RAG 主循环：
-    Agent 自主决定是否调用工具，基于检索结果生成回答
-    """
+    raw_arguments = getattr(function, "arguments", "")
+    try:
+        arguments = json.loads(raw_arguments)
+    except (TypeError, json.JSONDecodeError):
+        return "工具调用参数不是有效 JSON。"
+
+    if not isinstance(arguments, dict):
+        return "工具调用参数必须是 JSON 对象。"
+
+    query_text = arguments.get("query")
+    if not isinstance(query_text, str) or not query_text.strip():
+        return "工具调用缺少非空字符串参数 query。"
+
+    return search_fn(query_text.strip())
+
+
+def run_agent_loop(
+    question: str,
+    *,
+    api_client,
+    search_fn,
+    max_tool_rounds: int = 5,
+) -> str:
+    """执行支持多工具、多轮和安全失败的 Agent 工具循环。"""
+    if max_tool_rounds < 0:
+        raise ValueError("max_tool_rounds 不能小于 0")
+
     messages = [
         {
             "role": "system",
@@ -111,80 +169,89 @@ def ask_agent(question: str) -> str:
         {"role": "user", "content": question}
     ]
 
-    # 第一次调用：让 Agent 判断是否需要检索
-    response = client.chat.completions.create(
-        model=MODEL,
-        messages=messages,
-        tools=tools,
-    )
-
-    message = response.choices[0].message
-
-    # Agent 决定调用工具
-    if message.tool_calls:
-        tool_call = message.tool_calls[0]
-        arguments = json.loads(tool_call.function.arguments)
-        query_text = arguments["query"]
-
-        print(f"  → Agent 决定检索：\"{query_text}\"")
-
-        search_results = execute_search(query_text)
-        print(f"  → 检索到 {search_results.count('[结果')} 条相关内容")
-
-        # 将工具调用和结果加入消息历史
-        messages.append(message)
-        messages.append({
-            "role": "tool",
-            "tool_call_id": tool_call.id,
-            "content": search_results
-        })
-
-        # 第二次调用：基于检索结果生成最终回答
-        final_response = client.chat.completions.create(
+    tool_rounds = 0
+    while True:
+        response = api_client.chat.completions.create(
             model=MODEL,
             messages=messages,
             tools=tools,
         )
-        return final_response.choices[0].message.content
+        choices = getattr(response, "choices", None)
+        if not choices:
+            return "模型未返回有效内容。"
 
-    # Agent 决定不调用工具，直接回答（如闲聊、常识问题）
-    print("  → Agent 直接回答（无需检索）")
-    return message.content
+        message = choices[0].message
+        tool_calls = getattr(message, "tool_calls", None) or []
+        if not tool_calls:
+            content = getattr(message, "content", None)
+            if isinstance(content, str) and content.strip():
+                return content
+            return "模型未返回有效内容。"
+
+        if tool_rounds >= max_tool_rounds:
+            return f"达到最大工具调用轮数（{max_tool_rounds}），任务已停止。"
+
+        messages.append(message)
+        for tool_call in tool_calls:
+            result = _tool_result(tool_call, search_fn)
+            messages.append({
+                "role": "tool",
+                "tool_call_id": getattr(tool_call, "id", ""),
+                "content": result,
+            })
+        tool_rounds += 1
 
 
-# ---------- 5. 测试用例 ----------
+def ask_agent(
+    question: str,
+    *,
+    api_client=None,
+    search_fn=None,
+    max_tool_rounds: int = 5,
+) -> str:
+    """使用默认依赖执行 Agentic RAG，也允许测试注入离线依赖。"""
+    model_client = api_client or create_model_client()
+    if search_fn is not None:
+        return run_agent_loop(
+            question,
+            api_client=model_client,
+            search_fn=search_fn,
+            max_tool_rounds=max_tool_rounds,
+        )
 
-test_cases = [
-    {
-        "question": "OB-4.2.1 版本和旧版本兼容吗？",
-        "expect": "需要检索（版本兼容性）"
-    },
-    {
-        "question": "遇到 E-4012 错误怎么解决？",
-        "expect": "需要检索（错误码）"
-    },
-    {
-        "question": "2024年Q3的总营收是多少？",
-        "expect": "需要检索（财务数据）"
-    },
-    {
-        "question": "你好，今天天气怎么样？",
-        "expect": "不需要检索（闲聊）"
-    },
-]
+    with create_db_client() as database:
+        if not database.has_collection(COLLECTION_NAME):
+            return "知识库尚未初始化，请先运行 d3_1_ingest.py。"
+        collection = database.get_collection(COLLECTION_NAME)
+        return run_agent_loop(
+            question,
+            api_client=model_client,
+            search_fn=lambda query: execute_search(query, collection),
+            max_tool_rounds=max_tool_rounds,
+        )
 
-print("=" * 60)
-print("Agentic RAG 演示")
-print("=" * 60)
 
-for i, case in enumerate(test_cases, 1):
-    print(f"\n【问题 {i}】{case['question']}")
-    print(f"  预期行为：{case['expect']}")
-    answer = ask_agent(case["question"])
-    print(f"  回答：{answer[:200]}{'...' if len(answer) > 200 else ''}")
-    print()
+def main():
+    test_cases = [
+        ("OB-4.2.1 版本和旧版本兼容吗？", "需要检索（版本兼容性）"),
+        ("遇到 E-4012 错误怎么解决？", "需要检索（错误码）"),
+        ("2024年Q3的总营收是多少？", "需要检索（财务数据）"),
+        ("你好，今天天气怎么样？", "不需要检索（闲聊）"),
+    ]
 
-print("=" * 60)
-print("✅ Agentic RAG 演示完成")
-print("   关键点：Agent 自主判断是否需要检索，而不是每次都查知识库")
-print("   这就是 'Agentic' 的含义——主动决策，而不是被动执行流程")
+    print("=" * 60)
+    print("Agentic RAG 演示")
+    print("=" * 60)
+    for index, (question, expected) in enumerate(test_cases, 1):
+        print(f"\n【问题 {index}】{question}")
+        print(f"  预期行为：{expected}")
+        answer = ask_agent(question)
+        print(f"  回答：{answer[:200]}{'...' if len(answer) > 200 else ''}")
+        print()
+
+    print("=" * 60)
+    print("✅ Agentic RAG 演示完成")
+
+
+if __name__ == "__main__":
+    main()

--- a/code/D3/d3_3_compare.py
+++ b/code/D3/d3_3_compare.py
@@ -22,15 +22,14 @@ import pyseekdb
 
 # ---------- 0. 连接知识库 ----------
 
-db = pyseekdb.Client()
-collection_name = "d3_product_kb"
+DATABASE_PATH = Path(__file__).resolve().parent / "d3_seekdb"
+COLLECTION_NAME = "d3_product_kb"
+collection = None
 
-if not db.has_collection(collection_name):
-    print("❌ 未找到知识库，请先运行 d3_1_ingest.py 写入数据")
-    exit(1)
 
-collection = db.get_collection(collection_name)
-print(f">>> 已连接知识库：{collection_name}，共 {collection.count()} 条文档\n")
+def create_db_client():
+    """创建路径稳定的 seekdb 客户端。"""
+    return pyseekdb.Client(path=str(DATABASE_PATH))
 
 
 # ---------- 1. 辅助函数 ----------
@@ -72,11 +71,6 @@ def vector_with_metadata(query: str, metadata_filter: dict, n_results: int = 3) 
 
 # ---------- 2. 对比实验 ----------
 
-print("=" * 70)
-print("对比实验：纯向量检索 vs 增强检索（混合/元数据过滤）")
-print("=" * 70)
-
-# 测试用例：每个用例展示一种精确匹配场景
 test_cases = [
     {
         "desc": "场景一：精确错误码查询",
@@ -120,44 +114,54 @@ test_cases = [
     },
 ]
 
-vector_hits = 0
-enhanced_hits = 0
 
-for i, case in enumerate(test_cases, 1):
-    query = case["query"]
-    v_results = case["vector_fn"](query)
-    e_results = case["enhanced_fn"](query)
+def run_comparison(target_collection):
+    """运行检索对比实验。"""
+    global collection
+    collection = target_collection
+    vector_hits = 0
+    enhanced_hits = 0
 
-    v_top1 = get_top1_snippet(v_results)
-    e_top1 = get_top1_snippet(e_results)
+    for case in test_cases:
+        query = case["query"]
+        v_top1 = get_top1_snippet(case["vector_fn"](query))
+        e_top1 = get_top1_snippet(case["enhanced_fn"](query))
+        v_hit = case["correct"] in v_top1
+        e_hit = case["correct"] in e_top1
+        vector_hits += int(v_hit)
+        enhanced_hits += int(e_hit)
 
-    v_hit = case["correct"] in v_top1
-    e_hit = case["correct"] in e_top1
+        print(f"\n【{case['desc']}】")
+        print(f"  查询：\"{query}\"")
+        print(f"  纯向量检索 Top-1 {'✅' if v_hit else '❌'}：{v_top1}")
+        print(
+            f"  {case['enhanced_label']} Top-1 "
+            f"{'✅' if e_hit else '❌'}：{e_top1}"
+        )
+    return vector_hits, enhanced_hits
 
-    if v_hit:
-        vector_hits += 1
-    if e_hit:
-        enhanced_hits += 1
 
-    v_mark = "✅" if v_hit else "❌"
-    e_mark = "✅" if e_hit else "❌"
+def main():
+    with create_db_client() as database:
+        if not database.has_collection(COLLECTION_NAME):
+            print("❌ 未找到知识库，请先运行 d3_1_ingest.py 写入数据")
+            return
+        target_collection = database.get_collection(COLLECTION_NAME)
+        print(
+            f">>> 已连接知识库：{COLLECTION_NAME}，"
+            f"共 {target_collection.count()} 条文档\n"
+        )
+        print("=" * 70)
+        print("对比实验：纯向量检索 vs 增强检索（混合/元数据过滤）")
+        print("=" * 70)
+        vector_hits, enhanced_hits = run_comparison(target_collection)
 
-    print(f"\n【{case['desc']}】")
-    print(f"  查询：\"{query}\"")
-    print(f"  纯向量检索 Top-1 {v_mark}：{v_top1}")
-    print(f"  {case['enhanced_label']} Top-1 {e_mark}：{e_top1}")
+    print()
+    print("=" * 70)
+    print("汇总结果：")
+    print(f"  纯向量检索命中率：{vector_hits}/{len(test_cases)}")
+    print(f"  增强检索命中率：  {enhanced_hits}/{len(test_cases)}")
 
-# 汇总
-print()
-print("=" * 70)
-print("汇总结果：")
-print(f"  纯向量检索命中率：{vector_hits}/{len(test_cases)} = {vector_hits/len(test_cases)*100:.0f}%")
-print(f"  增强检索命中率：  {enhanced_hits}/{len(test_cases)} = {enhanced_hits/len(test_cases)*100:.0f}%")
-print()
-print("三种检索能力的适用场景：")
-print("  向量语义检索  → 理解用户意图，找语义相关内容（适合开放式问题）")
-print("  全文关键词检索 → 精确匹配错误码、函数名、专有名词（适合精确标识符）")
-print("  元数据过滤    → 精确匹配版本号、分类等结构化字段（适合有明确属性的查询）")
-print()
-print("结论：生产级 RAG 需要三种能力组合使用，而不是只用向量搜索。")
-print("      seekdb 在一个引擎内原生支持三种检索，不需要维护多套系统。")
+
+if __name__ == "__main__":
+    main()

--- a/code/D3/d3_4_production.py
+++ b/code/D3/d3_4_production.py
@@ -22,30 +22,32 @@ from openai import OpenAI
 
 # ---------- 0. 连接知识库 ----------
 
-db = pyseekdb.Client()
-collection_name = "d3_product_kb"
-
-if not db.has_collection(collection_name):
-    print("❌ 未找到知识库，请先运行 d3_1_ingest.py 写入数据")
-    exit(1)
-
-collection = db.get_collection(collection_name)
-print(f">>> 已连接知识库：{collection_name}，共 {collection.count()} 条文档\n")
-
-client = OpenAI(
-    api_key=Config.SILICONFLOW_API_KEY,
-    base_url=Config.SILICONFLOW_BASE_URL,
-)
+DATABASE_PATH = Path(__file__).resolve().parent / "d3_seekdb"
+COLLECTION_NAME = "d3_product_kb"
 MODEL = "deepseek-ai/DeepSeek-V3"
+
+
+def create_db_client():
+    """创建路径稳定的 seekdb 客户端。"""
+    return pyseekdb.Client(path=str(DATABASE_PATH))
+
+
+def create_model_client():
+    return OpenAI(
+        api_key=Config.SILICONFLOW_API_KEY,
+        base_url=Config.SILICONFLOW_BASE_URL,
+    )
 
 
 # ---------- 1. 工具描述质量的影响 ----------
 
-print("=" * 60)
-print("【要点一】工具描述质量对 Agent 行为的影响")
-print("=" * 60)
-
-def ask_with_tool_desc(question: str, tool_description: str, label: str) -> str:
+def ask_with_tool_desc(
+    question: str,
+    tool_description: str,
+    label: str,
+    *,
+    api_client,
+) -> str:
     """用指定的工具描述发起 Agent 调用"""
     tools = [{
         "type": "function",
@@ -67,81 +69,40 @@ def ask_with_tool_desc(question: str, tool_description: str, label: str) -> str:
         {"role": "user", "content": question}
     ]
 
-    response = client.chat.completions.create(
+    response = api_client.chat.completions.create(
         model=MODEL,
         messages=messages,
         tools=tools,
     )
 
-    message = response.choices[0].message
-    if message.tool_calls:
-        return f"[{label}] ✅ Agent 调用了工具，查询：\"{json.loads(message.tool_calls[0].function.arguments)['query']}\""
-    else:
-        return f"[{label}] ⚠️  Agent 直接回答（未调用工具）：\"{message.content[:80]}...\""
+    choices = getattr(response, "choices", None)
+    if not choices:
+        return f"[{label}] ⚠️  模型未返回有效内容"
+    message = getattr(choices[0], "message", None)
+    if message is None:
+        return f"[{label}] ⚠️  模型未返回有效内容"
+
+    if getattr(message, "tool_calls", None):
+        tool_call = message.tool_calls[0]
+        function = getattr(tool_call, "function", None)
+        function_name = getattr(function, "name", "")
+        if function_name != "search_knowledge_base":
+            return f"[{label}] ⚠️  未知工具：{function_name or '未提供名称'}"
+        try:
+            arguments = json.loads(getattr(function, "arguments", ""))
+        except (TypeError, json.JSONDecodeError):
+            return f"[{label}] ⚠️  工具调用参数不是有效 JSON"
+        query = arguments.get("query") if isinstance(arguments, dict) else None
+        if not isinstance(query, str) or not query.strip():
+            return f"[{label}] ⚠️  工具调用缺少非空字符串参数 query"
+        return f"[{label}] ✅ Agent 调用了工具，查询：\"{query.strip()}\""
+
+    content = getattr(message, "content", None)
+    if not isinstance(content, str) or not content.strip():
+        return f"[{label}] ⚠️  模型未返回有效内容"
+    return f"[{label}] ⚠️  Agent 直接回答（未调用工具）：\"{content[:80]}...\""
 
 
-# 测试问题：这个问题应该触发工具调用
-test_q = "OB-4.2.1 版本和旧版本兼容吗？"
-print(f"\n测试问题：{test_q}\n")
-
-# 模糊的工具描述
-vague_desc = "查询数据库"
-result1 = ask_with_tool_desc(test_q, vague_desc, "模糊描述")
-print(result1)
-
-# 清晰的工具描述
-clear_desc = (
-    "从产品知识库中检索相关信息。"
-    "当用户询问产品功能、错误码、版本信息、性能优化、营收数据等问题时使用。"
-    "查询文本应保留用户问题中的关键词和专有名词（如版本号、错误码）。"
-)
-result2 = ask_with_tool_desc(test_q, clear_desc, "清晰描述")
-print(result2)
-
-print()
-print("结论：工具描述越清晰，Agent 越能在正确的时机调用工具。")
-print("      模糊的描述会导致 Agent 不知道什么时候该用这个工具。")
-
-
-# ---------- 2. top_k 参数的取舍 ----------
-
-print()
-print("=" * 60)
-print("【要点二】top_k 参数的取舍")
-print("=" * 60)
-
-query = "数据库性能优化"
-print(f"\n查询：\"{query}\"")
-print()
-
-for top_k in [1, 3, 5, 8]:
-    results = collection.hybrid_search(
-        query={"where_document": {"$contains": "性能"}, "n_results": top_k + 2},
-        knn={"query_texts": [query], "n_results": top_k + 2},
-        rank={"rrf": {}},
-        n_results=top_k,
-    )
-    docs = results.get("documents", [[]])[0]
-    # 计算相关内容比例（包含"性能"或"优化"的文档）
-    relevant = sum(1 for d in docs if "性能" in d or "优化" in d or "索引" in d or "分区" in d)
-    print(f"  top_k={top_k}：返回 {len(docs)} 条，其中相关 {relevant} 条，"
-          f"噪声比例 {(len(docs)-relevant)/max(len(docs),1)*100:.0f}%")
-
-print()
-print("结论：top_k 设太小可能遗漏关键信息，设太大会引入噪声干扰模型推理。")
-print("      实践中 top_k=3~5 是常见起点，根据数据密度和查询类型调整。")
-
-
-# ---------- 3. 增量更新知识库 ----------
-
-print()
-print("=" * 60)
-print("【要点三】增量更新知识库（不需要全量重建）")
-print("=" * 60)
-
-print(f"\n当前知识库文档数：{collection.count()}")
-
-# 模拟新增一条文档（比如新版本发布说明）
 new_doc = {
     "id": "kb_013",
     "content": "OB-4.3.0 版本新特性：支持向量索引加速，引入自适应压缩算法，存储空间减少 30%。与 OB-4.2.x 完全兼容，支持滚动升级。",
@@ -149,35 +110,77 @@ new_doc = {
     "version": "4.3.0"
 }
 
-# 增量写入（不删除已有数据）
-# 先检查是否已存在，避免重复写入报错
-existing = collection.get(ids=[new_doc["id"]])
-if not existing.get("ids"):
-    collection.add(
-        ids=[new_doc["id"]],
-        documents=[new_doc["content"]],
-        metadatas=[{"doc_type": new_doc["doc_type"], "version": new_doc["version"]}],
+
+def upsert_document(collection, document):
+    """原子写入单条文档，避免检查后写入竞态。"""
+    collection.upsert(
+        ids=[document["id"]],
+        documents=[document["content"]],
+        metadatas=[{
+            "doc_type": document["doc_type"],
+            "version": document["version"],
+        }],
     )
-    print(f"增量写入 1 条新文档后：{collection.count()} 条")
-else:
-    print(f"文档已存在，当前共 {collection.count()} 条")
 
-# 验证新文档可以被检索到（用元数据过滤，因为版本号含点号全文搜索不支持）
-results = collection.query(
-    query_texts=["OB-4.3.0 版本特性"],
-    where={"version": "4.3.0"},
-    n_results=1,
-)
-docs = results.get("documents", [[]])[0]
-if docs and "4.3.0" in docs[0]:
-    print(f"✅ 新文档可以被检索到：{docs[0][:60]}...")
-else:
-    print("⚠️  新文档未被检索到")
 
-print()
-print("结论：seekdb 支持对已有集合追加数据，不需要每次都删库重建。")
-print("      生产环境中，'数据新鲜度'往往比'检索算法精细调优'更影响用户体验。")
+def main():
+    with create_db_client() as database:
+        if not database.has_collection(COLLECTION_NAME):
+            print("❌ 未找到知识库，请先运行 d3_1_ingest.py 写入数据")
+            return
+        collection = database.get_collection(COLLECTION_NAME)
+        client = create_model_client()
+        print(
+            f">>> 已连接知识库：{COLLECTION_NAME}，"
+            f"共 {collection.count()} 条文档\n"
+        )
 
-print()
-print("=" * 60)
-print("✅ d3_4 完成！三个生产要点演示结束。")
+        print("=" * 60)
+        print("【要点一】工具描述质量对 Agent 行为的影响")
+        print("=" * 60)
+        test_q = "OB-4.2.1 版本和旧版本兼容吗？"
+        print(
+            ask_with_tool_desc(
+                test_q,
+                "查询数据库",
+                "模糊描述",
+                api_client=client,
+            )
+        )
+        clear_desc = (
+            "从产品知识库中检索相关信息。"
+            "当用户询问产品功能、错误码、版本信息、性能优化、营收数据等问题时使用。"
+        )
+        print(
+            ask_with_tool_desc(
+                test_q,
+                clear_desc,
+                "清晰描述",
+                api_client=client,
+            )
+        )
+
+        print("\n【要点二】top_k 参数的取舍")
+        query = "数据库性能优化"
+        for top_k in [1, 3, 5, 8]:
+            results = collection.hybrid_search(
+                query={
+                    "where_document": {"$contains": "性能"},
+                    "n_results": top_k + 2,
+                },
+                knn={"query_texts": [query], "n_results": top_k + 2},
+                rank={"rrf": {}},
+                n_results=top_k,
+            )
+            docs = results.get("documents", [[]])[0]
+            print(f"  top_k={top_k}：返回 {len(docs)} 条")
+
+        print("\n【要点三】增量更新知识库")
+        upsert_document(collection, new_doc)
+        print(f"增量写入或更新 1 条文档后：{collection.count()} 条")
+
+    print("\n✅ d3_4 完成！三个生产要点演示结束。")
+
+
+if __name__ == "__main__":
+    main()

--- a/code/D3/test_d3_hardening.py
+++ b/code/D3/test_d3_hardening.py
@@ -1,0 +1,448 @@
+import contextlib
+import io
+import json
+import runpy
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+D3_DIR = Path(__file__).resolve().parent
+
+
+class FakeCollection:
+    def __init__(self):
+        self.add_calls = []
+        self.upsert_calls = []
+
+    def add(self, **kwargs):
+        self.add_calls.append(kwargs)
+
+    def upsert(self, **kwargs):
+        self.upsert_calls.append(kwargs)
+
+    def count(self):
+        return 13
+
+    def get(self, **kwargs):
+        return {"ids": ["kb_013"]}
+
+    def query(self, **kwargs):
+        return {
+            "documents": [["OB-4.3.0 版本新特性"]],
+            "metadatas": [[{"version": "4.3.0"}]],
+        }
+
+    def hybrid_search(self, **kwargs):
+        return {
+            "documents": [["数据库性能优化"]],
+            "metadatas": [[{"version": "4.2"}]],
+        }
+
+
+class FakeDatabase:
+    def __init__(self):
+        self.collection = FakeCollection()
+        self.deleted = []
+        self.get_or_create_calls = []
+
+    def has_collection(self, name):
+        return True
+
+    def delete_collection(self, name):
+        self.deleted.append(name)
+
+    def create_collection(self, name):
+        return self.collection
+
+    def get_collection(self, name):
+        return self.collection
+
+    def get_or_create_collection(self, name):
+        self.get_or_create_calls.append(name)
+        return self.collection
+
+
+class FakeMessage:
+    def __init__(self, *, content=None, tool_calls=None):
+        self.content = content
+        self.tool_calls = tool_calls or []
+
+
+class FakeToolCall:
+    def __init__(self, call_id, name, arguments):
+        self.id = call_id
+        self.function = types.SimpleNamespace(name=name, arguments=arguments)
+
+
+class SequenceCompletions:
+    def __init__(self, messages):
+        self._messages = list(messages)
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        if not self._messages:
+            raise AssertionError("模型调用次数超出测试预期")
+        message = self._messages.pop(0)
+        return types.SimpleNamespace(
+            choices=[types.SimpleNamespace(message=message)]
+        )
+
+
+class SequenceClient:
+    def __init__(self, messages):
+        self.completions = SequenceCompletions(messages)
+        self.chat = types.SimpleNamespace(completions=self.completions)
+
+
+def load_script(filename):
+    database = FakeDatabase()
+    client_paths = []
+
+    def make_database(*args, **kwargs):
+        client_paths.append(kwargs.get("path"))
+        return database
+
+    direct_answer = FakeMessage(content="测试回答")
+    default_client = SequenceClient([direct_answer] * 20)
+    fake_pyseekdb = types.SimpleNamespace(Client=make_database)
+    fake_openai = types.SimpleNamespace(OpenAI=lambda **kwargs: default_client)
+
+    with patch.dict(
+        sys.modules,
+        {"pyseekdb": fake_pyseekdb, "openai": fake_openai},
+    ), contextlib.redirect_stdout(io.StringIO()):
+        namespace = runpy.run_path(str(D3_DIR / filename), run_name="d3_test")
+
+    return namespace, database, client_paths
+
+
+class DatabaseSafetyTests(unittest.TestCase):
+    def test_importing_scripts_does_not_open_or_modify_database(self):
+        for filename in (
+            "d3_1_ingest.py",
+            "d3_2_agentic_rag.py",
+            "d3_3_compare.py",
+            "d3_4_production.py",
+        ):
+            with self.subTest(filename=filename):
+                _, database, client_paths = load_script(filename)
+                self.assertEqual([], client_paths)
+                self.assertEqual([], database.deleted)
+
+    def test_database_path_is_anchored_to_d3_directory(self):
+        expected = D3_DIR / "d3_seekdb"
+        for filename in (
+            "d3_1_ingest.py",
+            "d3_2_agentic_rag.py",
+            "d3_3_compare.py",
+            "d3_4_production.py",
+        ):
+            with self.subTest(filename=filename):
+                namespace, _, client_paths = load_script(filename)
+                create_db_client = namespace.get("create_db_client")
+                self.assertIsNotNone(create_db_client)
+                create_db_client()
+                self.assertEqual([str(expected)], client_paths)
+
+    def test_ingest_reuses_collection_and_upserts_documents(self):
+        namespace, _, _ = load_script("d3_1_ingest.py")
+        build_knowledge_base = namespace.get("build_knowledge_base")
+        self.assertIsNotNone(build_knowledge_base)
+
+        database = FakeDatabase()
+        collection = build_knowledge_base(database)
+
+        self.assertEqual(["d3_product_kb"], database.get_or_create_calls)
+        self.assertEqual([], database.deleted)
+        self.assertEqual([], collection.add_calls)
+        self.assertEqual(1, len(collection.upsert_calls))
+        self.assertEqual(12, len(collection.upsert_calls[0]["ids"]))
+
+    def test_incremental_update_uses_atomic_upsert(self):
+        namespace, _, _ = load_script("d3_4_production.py")
+        upsert_document = namespace.get("upsert_document")
+        self.assertIsNotNone(upsert_document)
+
+        collection = FakeCollection()
+        upsert_document(
+            collection,
+            {
+                "id": "kb_013",
+                "content": "新版本",
+                "doc_type": "release_notes",
+                "version": "4.3.0",
+            },
+        )
+
+        self.assertEqual([], collection.add_calls)
+        self.assertEqual(1, len(collection.upsert_calls))
+        self.assertEqual(["kb_013"], collection.upsert_calls[0]["ids"])
+
+
+class RetrievalTests(unittest.TestCase):
+    def test_keyword_extractor_preserves_error_code_and_quarter(self):
+        namespace, _, _ = load_script("d3_2_agentic_rag.py")
+        extract_search_keyword = namespace.get("extract_search_keyword")
+        self.assertIsNotNone(extract_search_keyword)
+
+        self.assertEqual("E-4012", extract_search_keyword("遇到 E-4012 错误怎么解决？"))
+        self.assertEqual("Q3", extract_search_keyword("2024年Q3的总营收是多少？"))
+
+    def test_execute_search_uses_extracted_keyword(self):
+        namespace, _, _ = load_script("d3_2_agentic_rag.py")
+        execute_search = namespace["execute_search"]
+
+        class RecordingCollection(FakeCollection):
+            def __init__(self):
+                super().__init__()
+                self.hybrid_calls = []
+
+            def hybrid_search(self, **kwargs):
+                self.hybrid_calls.append(kwargs)
+                return {"documents": [["错误码 E-4012"]]}
+
+        collection = RecordingCollection()
+        try:
+            result = execute_search("遇到 E-4012 错误怎么解决？", collection)
+        except TypeError as exc:
+            self.fail(f"execute_search 必须支持注入 collection：{exc}")
+
+        self.assertIn("E-4012", result)
+        self.assertEqual(
+            "E-4012",
+            collection.hybrid_calls[0]["query"]["where_document"]["$contains"],
+        )
+
+
+class ToolLoopTests(unittest.TestCase):
+    def setUp(self):
+        namespace, _, _ = load_script("d3_2_agentic_rag.py")
+        self.run_agent_loop = namespace.get("run_agent_loop")
+
+    def require_loop(self):
+        self.assertIsNotNone(self.run_agent_loop)
+        return self.run_agent_loop
+
+    def test_executes_every_tool_call_in_one_model_message(self):
+        run_agent_loop = self.require_loop()
+        client = SequenceClient(
+            [
+                FakeMessage(
+                    tool_calls=[
+                        FakeToolCall(
+                            "call_1",
+                            "search_knowledge_base",
+                            json.dumps({"query": "E-4012"}),
+                        ),
+                        FakeToolCall(
+                            "call_2",
+                            "search_knowledge_base",
+                            json.dumps({"query": "Q3"}),
+                        ),
+                    ]
+                ),
+                FakeMessage(content="综合回答"),
+            ]
+        )
+        queries = []
+
+        answer = run_agent_loop(
+            "请综合回答",
+            api_client=client,
+            search_fn=lambda query: queries.append(query) or f"结果：{query}",
+        )
+
+        self.assertEqual("综合回答", answer)
+        self.assertEqual(["E-4012", "Q3"], queries)
+        tool_messages = [
+            item
+            for item in client.completions.calls[1]["messages"]
+            if isinstance(item, dict) and item.get("role") == "tool"
+        ]
+        self.assertEqual(["call_1", "call_2"], [item["tool_call_id"] for item in tool_messages])
+
+    def test_supports_multiple_tool_rounds(self):
+        run_agent_loop = self.require_loop()
+        client = SequenceClient(
+            [
+                FakeMessage(
+                    tool_calls=[
+                        FakeToolCall(
+                            "call_1",
+                            "search_knowledge_base",
+                            '{"query": "第一轮"}',
+                        )
+                    ]
+                ),
+                FakeMessage(
+                    tool_calls=[
+                        FakeToolCall(
+                            "call_2",
+                            "search_knowledge_base",
+                            '{"query": "第二轮"}',
+                        )
+                    ]
+                ),
+                FakeMessage(content="最终回答"),
+            ]
+        )
+        queries = []
+
+        answer = run_agent_loop(
+            "多轮问题",
+            api_client=client,
+            search_fn=lambda query: queries.append(query) or query,
+        )
+
+        self.assertEqual("最终回答", answer)
+        self.assertEqual(["第一轮", "第二轮"], queries)
+
+    def test_unknown_tool_and_invalid_json_become_tool_errors(self):
+        run_agent_loop = self.require_loop()
+        client = SequenceClient(
+            [
+                FakeMessage(
+                    tool_calls=[
+                        FakeToolCall("call_1", "unknown_tool", "{}"),
+                        FakeToolCall(
+                            "call_2",
+                            "search_knowledge_base",
+                            "{bad json",
+                        ),
+                    ]
+                ),
+                FakeMessage(content="已根据错误信息调整"),
+            ]
+        )
+        queries = []
+
+        answer = run_agent_loop(
+            "错误工具",
+            api_client=client,
+            search_fn=lambda query: queries.append(query) or query,
+        )
+
+        self.assertEqual("已根据错误信息调整", answer)
+        self.assertEqual([], queries)
+        tool_messages = [
+            item
+            for item in client.completions.calls[1]["messages"]
+            if isinstance(item, dict) and item.get("role") == "tool"
+        ]
+        self.assertIn("未知工具", tool_messages[0]["content"])
+        self.assertIn("参数不是有效 JSON", tool_messages[1]["content"])
+
+    def test_empty_final_content_returns_safe_message(self):
+        run_agent_loop = self.require_loop()
+        client = SequenceClient([FakeMessage(content=None)])
+
+        answer = run_agent_loop(
+            "空响应",
+            api_client=client,
+            search_fn=lambda query: query,
+        )
+
+        self.assertEqual("模型未返回有效内容。", answer)
+
+    def test_stops_after_maximum_tool_rounds(self):
+        run_agent_loop = self.require_loop()
+        endless_calls = [
+            FakeMessage(
+                tool_calls=[
+                    FakeToolCall(
+                        f"call_{index}",
+                        "search_knowledge_base",
+                        json.dumps({"query": f"query_{index}"}),
+                    )
+                ]
+            )
+            for index in range(1, 5)
+        ]
+        client = SequenceClient(endless_calls)
+        queries = []
+
+        answer = run_agent_loop(
+            "无限调用",
+            api_client=client,
+            search_fn=lambda query: queries.append(query) or query,
+            max_tool_rounds=2,
+        )
+
+        self.assertIn("达到最大工具调用轮数（2）", answer)
+        self.assertEqual(["query_1", "query_2"], queries)
+        self.assertEqual(3, len(client.completions.calls))
+
+
+class ProductionDemoToolSafetyTests(unittest.TestCase):
+    def test_tool_description_demo_handles_missing_choice_or_message(self):
+        namespace, _, _ = load_script("d3_4_production.py")
+        ask_with_tool_desc = namespace["ask_with_tool_desc"]
+
+        responses = (
+            types.SimpleNamespace(choices=[]),
+            types.SimpleNamespace(choices=[types.SimpleNamespace(message=None)]),
+        )
+
+        for response in responses:
+            with self.subTest(response=response):
+                completions = types.SimpleNamespace(create=lambda **_kwargs: response)
+                client = types.SimpleNamespace(
+                    chat=types.SimpleNamespace(completions=completions)
+                )
+                result = ask_with_tool_desc(
+                    "测试问题",
+                    "测试描述",
+                    "测试",
+                    api_client=client,
+                )
+                self.assertIn("模型未返回有效内容", result)
+
+    def test_tool_description_demo_handles_untrusted_model_output(self):
+        namespace, _, _ = load_script("d3_4_production.py")
+        ask_with_tool_desc = namespace["ask_with_tool_desc"]
+
+        cases = [
+            (
+                FakeMessage(
+                    tool_calls=[
+                        FakeToolCall("call_1", "unknown_tool", "{}")
+                    ]
+                ),
+                "未知工具",
+            ),
+            (
+                FakeMessage(
+                    tool_calls=[
+                        FakeToolCall(
+                            "call_2",
+                            "search_knowledge_base",
+                            "{bad json",
+                        )
+                    ]
+                ),
+                "参数不是有效 JSON",
+            ),
+            (FakeMessage(content=None), "未返回有效内容"),
+        ]
+
+        for message, expected in cases:
+            with self.subTest(expected=expected):
+                client = SequenceClient([message])
+                try:
+                    result = ask_with_tool_desc(
+                        "测试问题",
+                        "测试描述",
+                        "测试",
+                        api_client=client,
+                    )
+                except (KeyError, TypeError, json.JSONDecodeError) as exc:
+                    self.fail(f"模型输出不可信时不应崩溃：{exc}")
+                self.assertIn(expected, result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/D4/d4_1_react_loop.py
+++ b/code/D4/d4_1_react_loop.py
@@ -109,6 +109,74 @@ tool_functions = {
 
 # ---------- 3. ReAct 推理循环 ----------
 
+def _require_response_message(response):
+    """把供应商空响应转换成稳定、可诊断的异常。"""
+    choices = getattr(response, "choices", None)
+    if not choices:
+        raise RuntimeError("模型返回空响应：缺少 choices")
+    message = getattr(choices[0], "message", None)
+    if message is None:
+        raise RuntimeError("模型返回空响应：缺少 message")
+    return message
+
+
+def _validate_tool_call_batch(tool_calls, registered_tools, tool_definitions):
+    """整批校验工具名、JSON 参数和声明的必填字符串字段。"""
+    schemas = {}
+    for definition in tool_definitions:
+        function = definition.get("function", {}) if isinstance(definition, dict) else {}
+        name = function.get("name")
+        parameters = function.get("parameters")
+        if isinstance(name, str) and isinstance(parameters, dict):
+            schemas[name] = parameters
+
+    validated = []
+    for index, tool_call in enumerate(tool_calls, start=1):
+        function = getattr(tool_call, "function", None)
+        func_name = getattr(function, "name", None)
+        if not isinstance(func_name, str) or not func_name:
+            raise ValueError(f"第 {index} 个工具调用缺少有效名称")
+        if func_name not in registered_tools:
+            raise ValueError(f"模型请求了未注册的工具：{func_name}")
+
+        raw_arguments = getattr(function, "arguments", None)
+        try:
+            arguments = json.loads(raw_arguments)
+        except (TypeError, json.JSONDecodeError) as exc:
+            raise ValueError(f"工具 {func_name} 的参数不是合法 JSON") from exc
+        if not isinstance(arguments, dict):
+            raise ValueError(f"工具 {func_name} 的 JSON 参数必须是对象")
+
+        schema = schemas.get(func_name)
+        if not isinstance(schema, dict):
+            raise ValueError(f"工具 {func_name} 缺少可校验的参数 schema")
+        required = schema.get("required", [])
+        properties = schema.get("properties", {})
+        if not isinstance(required, list) or not isinstance(properties, dict):
+            raise ValueError(f"工具 {func_name} 的参数 schema 无效")
+        for field_name in required:
+            if field_name not in arguments:
+                raise ValueError(f"工具 {func_name} 缺少必填参数 {field_name}")
+            field_schema = properties.get(field_name, {})
+            if (
+                isinstance(field_schema, dict)
+                and field_schema.get("type") == "string"
+                and not isinstance(arguments[field_name], str)
+            ):
+                raise ValueError(f"工具 {func_name} 的参数 {field_name} 必须是字符串")
+
+        validated.append((tool_call, func_name, arguments))
+    return validated
+
+
+def _require_final_content(message) -> str:
+    """最终回答必须是非空文本。"""
+    content = getattr(message, "content", None)
+    if not isinstance(content, str) or not content.strip():
+        raise RuntimeError("模型返回空响应：缺少最终回答内容")
+    return content
+
+
 def agent_loop(question: str, max_steps: int = 5) -> str:
     """
     ReAct 推理循环：
@@ -141,17 +209,21 @@ def agent_loop(question: str, max_steps: int = 5) -> str:
             tools=tools,
         )
 
-        message = response.choices[0].message
+        message = _require_response_message(response)
 
         # 检查 Agent 是否决定调用工具
-        if message.tool_calls:
+        tool_calls = getattr(message, "tool_calls", None)
+        if tool_calls:
+            validated_calls = _validate_tool_call_batch(
+                tool_calls,
+                tool_functions,
+                tools,
+            )
+
             # 行动：执行工具调用
             messages.append(message)
 
-            for tool_call in message.tool_calls:
-                func_name = tool_call.function.name
-                arguments = json.loads(tool_call.function.arguments)
-
+            for tool_call, func_name, arguments in validated_calls:
                 print(f"  [步骤 {step}] 调用工具：{func_name}({arguments})")
 
                 # 执行工具
@@ -167,7 +239,7 @@ def agent_loop(question: str, max_steps: int = 5) -> str:
         else:
             # Agent 决定不再调用工具，直接给出最终回答
             print(f"  [步骤 {step}] Agent 给出最终回答（共 {step} 步）")
-            return message.content
+            return _require_final_content(message)
 
     # 达到最大步数限制
     print(f"  [警告] 达到最大步数限制（{max_steps}步），强制结束")

--- a/code/D4/d4_3_with_memory.py
+++ b/code/D4/d4_3_with_memory.py
@@ -6,6 +6,7 @@ from config import Config
 import json
 import time
 import math
+import uuid
 from openai import OpenAI
 import pyseekdb
 
@@ -25,27 +26,55 @@ import pyseekdb
 
 # ---------- 1. 初始化 ----------
 
-client = OpenAI(
-    api_key=Config.SILICONFLOW_API_KEY,
-    base_url=Config.SILICONFLOW_BASE_URL,
-)
 MODEL = "deepseek-ai/DeepSeek-V3"
-
-# 初始化 seekdb，用于存储记忆
-db = pyseekdb.Client(path="./memory.db")
 MEMORY_COLLECTION = "user_memory_demo"
+D4_DIR = Path(__file__).resolve().parent
+MEMORY_DB_PATH = D4_DIR / "memory.db"
 
-# 如果已存在则先清空，确保演示效果干净
-if db.has_collection(MEMORY_COLLECTION):
-    db.delete_collection(MEMORY_COLLECTION)
-memory_col = db.create_collection(name=MEMORY_COLLECTION)
+client = None
+db = None
+memory_col = None
 
-print(">>> 记忆库已初始化（演示模式：每次运行重置）")
+
+def initialize_runtime(*, api_client=None, database=None):
+    """显式创建外部依赖；演示库每次运行都重置。"""
+    global client, db, memory_col
+    client = api_client if api_client is not None else OpenAI(
+        api_key=Config.SILICONFLOW_API_KEY,
+        base_url=Config.SILICONFLOW_BASE_URL,
+    )
+    db = database if database is not None else pyseekdb.Client(
+        path=str(MEMORY_DB_PATH)
+    )
+    if db.has_collection(MEMORY_COLLECTION):
+        db.delete_collection(MEMORY_COLLECTION)
+    memory_col = db.create_collection(name=MEMORY_COLLECTION)
+    print(">>> 记忆库已初始化（演示模式：每次运行重置）")
+    return memory_col
+
+
+def _require_model_client(api_client=None):
+    active_client = api_client if api_client is not None else client
+    if active_client is None:
+        raise RuntimeError("请先调用 initialize_runtime() 初始化模型客户端")
+    return active_client
+
+
+def _require_memory_collection(collection=None):
+    active_collection = collection if collection is not None else memory_col
+    if active_collection is None:
+        raise RuntimeError("请先调用 initialize_runtime() 初始化记忆库")
+    return active_collection
 
 
 # ---------- 2. 记忆管理函数 ----------
 
-def extract_facts_from_conversation(user_input: str, assistant_reply: str) -> list[str]:
+def extract_facts_from_conversation(
+    user_input: str,
+    assistant_reply: str,
+    *,
+    api_client=None,
+) -> list[str]:
     """
     用 LLM 从一轮对话中提炼关键事实。
     只提取关于用户的客观事实和偏好，不提取通用知识。
@@ -64,7 +93,7 @@ def extract_facts_from_conversation(user_input: str, assistant_reply: str) -> li
 
 如果没有值得记录的信息，返回：[]"""
 
-    response = client.chat.completions.create(
+    response = _require_model_client(api_client).chat.completions.create(
         model=MODEL,
         messages=[{"role": "user", "content": prompt}],
         temperature=0.1,
@@ -98,7 +127,7 @@ def extract_facts_from_conversation(user_input: str, assistant_reply: str) -> li
         return []
 
 
-def add_memory(facts: list[str]):
+def add_memory(facts: list[str], *, collection=None):
     """将提炼出的事实存入 seekdb 记忆库"""
     if not facts:
         return
@@ -108,8 +137,8 @@ def add_memory(facts: list[str]):
     documents = []
     metadatas = []
 
-    for i, fact in enumerate(facts):
-        memory_id = f"mem_{int(current_time)}_{i}"
+    for fact in facts:
+        memory_id = str(uuid.uuid4())
         ids.append(memory_id)
         documents.append(fact)
         metadatas.append({
@@ -117,19 +146,27 @@ def add_memory(facts: list[str]):
             "access_count": 0,  # 被检索到的次数（用于遗忘曲线）
         })
 
-    memory_col.add(ids=ids, documents=documents, metadatas=metadatas)
+    _require_memory_collection(collection).add(
+        ids=ids,
+        documents=documents,
+        metadatas=metadatas,
+    )
     print(f"  [记忆] 存入 {len(facts)} 条新记忆：{facts}")
 
 
-def search_memory(query: str, top_k: int = 5) -> list[str]:
+def search_memory(query: str, top_k: int = 5, *, collection=None) -> list[str]:
     """
     从记忆库中检索与当前问题相关的记忆。
     使用时效性权重：越新的记忆权重越高（模拟遗忘曲线）。
     """
-    if memory_col.count() == 0:
+    active_collection = _require_memory_collection(collection)
+    if active_collection.count() == 0:
         return []
 
-    results = memory_col.query(query_texts=[query], n_results=min(top_k, memory_col.count()))
+    results = active_collection.query(
+        query_texts=[query],
+        n_results=min(top_k, active_collection.count()),
+    )
 
     if not results or not results["documents"] or not results["documents"][0]:
         return []
@@ -154,7 +191,7 @@ def search_memory(query: str, top_k: int = 5) -> list[str]:
 
 # ---------- 3. 有记忆的 Agent ----------
 
-def chat_with_memory(user_input: str) -> str:
+def chat_with_memory(user_input: str, *, api_client=None, collection=None) -> str:
     """
     有记忆的 Agent：
     1. 推理前：从记忆库检索相关的用户信息，注入 System Prompt
@@ -162,7 +199,11 @@ def chat_with_memory(user_input: str) -> str:
     3. 推理后：从对话中提炼新事实，存入记忆库
     """
     # 步骤 1：检索相关记忆
-    relevant_memories = search_memory(query=user_input, top_k=5)
+    relevant_memories = search_memory(
+        query=user_input,
+        top_k=5,
+        collection=collection,
+    )
     memory_context = "\n".join([f"- {m}" for m in relevant_memories])
 
     # 步骤 2：构建包含记忆的 System Prompt
@@ -182,81 +223,71 @@ def chat_with_memory(user_input: str) -> str:
     ]
 
     # 步骤 3：调用模型
-    response = client.chat.completions.create(
+    active_client = _require_model_client(api_client)
+    response = active_client.chat.completions.create(
         model=MODEL,
         messages=messages
     )
     reply = response.choices[0].message.content
 
     # 步骤 4：提炼并存储新记忆
-    facts = extract_facts_from_conversation(user_input, reply)
-    add_memory(facts)
+    facts = extract_facts_from_conversation(
+        user_input,
+        reply,
+        api_client=active_client,
+    )
+    add_memory(facts, collection=collection)
 
     return reply
 
 
 # ---------- 4. 演示对话序列（与 d4_2 相同的问题，对比效果）----------
 
-print()
-print("=" * 60)
-print("有记忆 Agent 演示")
-print("=" * 60)
-print("观察：Agent 会记住用户信息，并在后续对话中体现")
-print()
+def run_demo():
+    """运行四轮有记忆对话演示。"""
+    print()
+    print("=" * 60)
+    print("有记忆 Agent 演示")
+    print("=" * 60)
+    print("观察：Agent 会记住用户信息，并在后续对话中体现")
+    print()
 
-# 第 1 轮：告诉 Agent 用户身份和偏好
-print("【第 1 轮】告知身份和偏好")
-print("-" * 40)
-q1 = "我是一个 Python 开发者，主要做后端开发，喜欢简洁的回答。"
-print(f"用户：{q1}")
-a1 = chat_with_memory(q1)
-print(f"Agent：{a1[:200]}{'...' if len(a1) > 200 else ''}")
-print(f"  [记忆库] 当前记忆数量：{memory_col.count()}")
+    questions = (
+        ("【第 1 轮】告知身份和偏好", "我是一个 Python 开发者，主要做后端开发，喜欢简洁的回答。"),
+        ("【第 2 轮】推荐 Web 框架", "帮我推荐一个 Web 框架"),
+        ("【第 3 轮】询问缓存方案", "怎么给我的项目加缓存？"),
+        ("【第 4 轮】模拟重启后继续昨天的话题", "继续昨天的话题，帮我选一个数据库方案。"),
+    )
+    for title, question in questions:
+        print(f"\n{title}")
+        print("-" * 40)
+        print(f"用户：{question}")
+        answer = chat_with_memory(question)
+        print(f"Agent：{answer[:300]}{'...' if len(answer) > 300 else ''}")
 
-# 第 2 轮：问 Web 框架推荐（Agent 应该记得你是 Python 开发者）
-print("\n【第 2 轮】推荐 Web 框架")
-print("-" * 40)
-q2 = "帮我推荐一个 Web 框架"
-print(f"用户：{q2}")
-a2 = chat_with_memory(q2)
-print(f"Agent：{a2[:300]}{'...' if len(a2) > 300 else ''}")
-print()
-print("  ✅ 注意：Agent 记得你是 Python 开发者，应该推荐 Python 框架")
+    active_collection = _require_memory_collection()
+    print()
+    print("=" * 60)
+    print("当前记忆库内容（共 {} 条）：".format(active_collection.count()))
+    print("-" * 40)
+    all_memories = active_collection.get()
+    if all_memories and all_memories["documents"]:
+        for index, document in enumerate(all_memories["documents"], 1):
+            print(f"  {index}. {document}")
 
-# 第 3 轮：问缓存方案（Agent 应该记得你喜欢简洁回答）
-print("\n【第 3 轮】询问缓存方案")
-print("-" * 40)
-q3 = "怎么给我的项目加缓存？"
-print(f"用户：{q3}")
-a3 = chat_with_memory(q3)
-print(f"Agent：{a3[:300]}{'...' if len(a3) > 300 else ''}")
-print()
-print("  ✅ 注意：Agent 记得你喜欢简洁回答，应该给出简洁的建议")
+    print()
+    print("=" * 60)
+    print("总结：有记忆 Agent 的优势")
+    print("  1. 记住用户身份和技术栈，推荐更有针对性")
+    print("  2. 记住用户偏好，回答风格更符合期望")
+    print("  3. 记忆持久化在 seekdb 中，重启后仍然有效")
+    print("  → 运行 d4_4_memory_agent.py 体验完整的交互式记忆 Agent")
 
-# 第 4 轮：模拟"第二天"重新打开（记忆已持久化在 seekdb 中）
-print("\n【第 4 轮】模拟重启后继续昨天的话题")
-print("-" * 40)
-q4 = "继续昨天的话题，帮我选一个数据库方案。"
-print(f"用户：{q4}")
-a4 = chat_with_memory(q4)
-print(f"Agent：{a4[:300]}{'...' if len(a4) > 300 else ''}")
-print()
-print("  ✅ 注意：Agent 记得你是 Python 开发者，应该推荐 Python 友好的数据库")
 
-# 展示当前记忆库内容
-print()
-print("=" * 60)
-print("当前记忆库内容（共 {} 条）：".format(memory_col.count()))
-print("-" * 40)
-all_memories = memory_col.get()
-if all_memories and all_memories["documents"]:
-    for i, doc in enumerate(all_memories["documents"], 1):
-        print(f"  {i}. {doc}")
+def main():
+    initialize_runtime()
+    run_demo()
 
-print()
-print("=" * 60)
-print("总结：有记忆 Agent 的优势")
-print("  1. 记住用户身份和技术栈，推荐更有针对性")
-print("  2. 记住用户偏好，回答风格更符合期望")
-print("  3. 记忆持久化在 seekdb 中，重启后仍然有效")
-print("  → 运行 d4_4_memory_agent.py 体验完整的交互式记忆 Agent")
+
+if __name__ == "__main__":
+    main()

--- a/code/D4/d4_4_memory_agent.py
+++ b/code/D4/d4_4_memory_agent.py
@@ -6,6 +6,7 @@ from config import Config
 import json
 import time
 import math
+import uuid
 from openai import OpenAI
 import pyseekdb
 
@@ -33,23 +34,47 @@ import pyseekdb
 
 # ---------- 1. 初始化 ----------
 
-client = OpenAI(
-    api_key=Config.SILICONFLOW_API_KEY,
-    base_url=Config.SILICONFLOW_BASE_URL,
-)
 MODEL = "deepseek-ai/DeepSeek-V3"
-
-# 记忆库持久化存储（不同于 d4_3，这里不重置，支持跨会话）
-db = pyseekdb.Client(path="./memory_persistent.db")
 MEMORY_COLLECTION = "user_memory_persistent"
+D4_DIR = Path(__file__).resolve().parent
+MEMORY_DB_PATH = D4_DIR / "memory_persistent.db"
 
-# 如果集合不存在则创建（已存在则复用，保留历史记忆）
-if not db.has_collection(MEMORY_COLLECTION):
-    memory_col = db.create_collection(name=MEMORY_COLLECTION)
-    print(">>> 首次运行，记忆库已创建")
-else:
-    memory_col = db.get_collection(name=MEMORY_COLLECTION)
-    print(f">>> 已加载历史记忆库，当前记忆数量：{memory_col.count()}")
+client = None
+db = None
+memory_col = None
+
+
+def initialize_runtime(*, api_client=None, database=None):
+    """显式创建外部依赖，并复用持久化记忆集合。"""
+    global client, db, memory_col
+    client = api_client if api_client is not None else OpenAI(
+        api_key=Config.SILICONFLOW_API_KEY,
+        base_url=Config.SILICONFLOW_BASE_URL,
+    )
+    db = database if database is not None else pyseekdb.Client(
+        path=str(MEMORY_DB_PATH)
+    )
+    if db.has_collection(MEMORY_COLLECTION):
+        memory_col = db.get_collection(name=MEMORY_COLLECTION)
+        print(f">>> 已加载历史记忆库，当前记忆数量：{memory_col.count()}")
+    else:
+        memory_col = db.create_collection(name=MEMORY_COLLECTION)
+        print(">>> 首次运行，记忆库已创建")
+    return memory_col
+
+
+def _require_model_client(api_client=None):
+    active_client = api_client if api_client is not None else client
+    if active_client is None:
+        raise RuntimeError("请先调用 initialize_runtime() 初始化模型客户端")
+    return active_client
+
+
+def _require_memory_collection(collection=None):
+    active_collection = collection if collection is not None else memory_col
+    if active_collection is None:
+        raise RuntimeError("请先调用 initialize_runtime() 初始化记忆库")
+    return active_collection
 
 
 # ---------- 2. 程序记忆（System Prompt）----------
@@ -67,7 +92,7 @@ BASE_SYSTEM_PROMPT = """你是一个友好、专业的技术助手。
 
 # ---------- 3. 记忆管理函数 ----------
 
-def extract_facts(user_input: str, assistant_reply: str) -> list[str]:
+def extract_facts(user_input: str, assistant_reply: str, *, api_client=None) -> list[str]:
     """用 LLM 从对话中提炼关键事实"""
     prompt = f"""从以下对话中提取关于用户的关键事实和偏好。
 只提取明确的、关于这位用户的信息（身份、技术栈、偏好、经历、踩过的坑等）。
@@ -80,7 +105,7 @@ def extract_facts(user_input: str, assistant_reply: str) -> list[str]:
 以 JSON 数组格式返回，每个元素是一条事实字符串。
 如果没有值得记录的信息，返回：[]"""
 
-    response = client.chat.completions.create(
+    response = _require_model_client(api_client).chat.completions.create(
         model=MODEL,
         messages=[{"role": "user", "content": prompt}],
         temperature=0.1,
@@ -110,25 +135,30 @@ def extract_facts(user_input: str, assistant_reply: str) -> list[str]:
         return []
 
 
-def save_memory(facts: list[str]):
+def save_memory(facts: list[str], *, collection=None):
     """将事实存入记忆库"""
     if not facts:
         return
 
     current_time = time.time()
-    ids = [f"mem_{int(current_time)}_{i}" for i in range(len(facts))]
+    ids = [str(uuid.uuid4()) for _ in facts]
     metadatas = [{"created_at": current_time, "access_count": 0} for _ in facts]
 
-    memory_col.add(ids=ids, documents=facts, metadatas=metadatas)
+    _require_memory_collection(collection).add(
+        ids=ids,
+        documents=facts,
+        metadatas=metadatas,
+    )
 
 
-def recall_memory(query: str, top_k: int = 5) -> list[str]:
+def recall_memory(query: str, top_k: int = 5, *, collection=None) -> list[str]:
     """检索相关记忆，带时效性权重"""
-    if memory_col.count() == 0:
+    active_collection = _require_memory_collection(collection)
+    if active_collection.count() == 0:
         return []
 
-    n = min(top_k, memory_col.count())
-    results = memory_col.query(query_texts=[query], n_results=n)
+    n = min(top_k, active_collection.count())
+    results = active_collection.query(query_texts=[query], n_results=n)
 
     if not results or not results["documents"] or not results["documents"][0]:
         return []
@@ -146,15 +176,16 @@ def recall_memory(query: str, top_k: int = 5) -> list[str]:
     return [m[0] for m in weighted]
 
 
-def show_memory_stats():
+def show_memory_stats(*, collection=None):
     """显示当前记忆库状态"""
-    count = memory_col.count()
+    active_collection = _require_memory_collection(collection)
+    count = active_collection.count()
     if count == 0:
         print("  [记忆库] 暂无记忆")
         return
 
     print(f"  [记忆库] 共 {count} 条记忆：")
-    all_mem = memory_col.get()
+    all_mem = active_collection.get()
     if all_mem and all_mem["documents"]:
         for i, doc in enumerate(all_mem["documents"][-5:], 1):  # 只显示最近 5 条
             print(f"    {i}. {doc}")
@@ -164,7 +195,13 @@ def show_memory_stats():
 
 # ---------- 4. 完整记忆 Agent ----------
 
-def chat(user_input: str, verbose: bool = True) -> str:
+def chat(
+    user_input: str,
+    verbose: bool = True,
+    *,
+    api_client=None,
+    collection=None,
+) -> str:
     """
     完整记忆 Agent：
     - 程序记忆（System Prompt）：定义行为规则
@@ -172,7 +209,7 @@ def chat(user_input: str, verbose: bool = True) -> str:
     - 情景记忆（seekdb）：存储过去的成功经验（本示例简化为同一个库）
     """
     # 1. 检索语义记忆
-    memories = recall_memory(query=user_input, top_k=5)
+    memories = recall_memory(query=user_input, top_k=5, collection=collection)
     memory_text = "\n".join([f"- {m}" for m in memories]) if memories else "暂无已知信息，请在对话中了解用户。"
 
     # 2. 构建带记忆的完整 System Prompt
@@ -189,61 +226,69 @@ def chat(user_input: str, verbose: bool = True) -> str:
     ]
 
     # 3. 调用模型
-    response = client.chat.completions.create(
+    active_client = _require_model_client(api_client)
+    response = active_client.chat.completions.create(
         model=MODEL,
         messages=messages
     )
     reply = response.choices[0].message.content
 
     # 4. 提炼并存储新记忆
-    facts = extract_facts(user_input, reply)
+    facts = extract_facts(user_input, reply, api_client=active_client)
     if facts and verbose:
         print(f"  [记忆提炼] {facts}")
-    save_memory(facts)
+    save_memory(facts, collection=collection)
 
     return reply
 
 
 # ---------- 5. 交互式主循环 ----------
 
-print()
-print("=" * 60)
-print("完整记忆 Agent（交互式）")
-print("=" * 60)
-print("输入 'quit' 或 '退出' 结束对话")
-print("输入 '/memory' 查看当前记忆库")
-print("输入 '/clear' 清空记忆库（重新开始）")
-print()
-
-# 显示当前记忆状态
-show_memory_stats()
-print()
-
-while True:
-    try:
-        user_input = input("你: ").strip()
-    except (EOFError, KeyboardInterrupt):
-        print("\n再见！")
-        break
-
-    if not user_input:
-        continue
-
-    if user_input.lower() in ["quit", "exit", "退出"]:
-        print("再见！记忆已保存，下次启动时会自动加载。")
-        break
-
-    if user_input == "/memory":
-        show_memory_stats()
-        continue
-
-    if user_input == "/clear":
-        db.delete_collection(MEMORY_COLLECTION)
-        memory_col = db.create_collection(name=MEMORY_COLLECTION)
-        print("  [记忆库] 已清空")
-        continue
-
+def run_interactive():
+    """启动交互式记忆 Agent。"""
+    global memory_col
     print()
-    reply = chat(user_input, verbose=True)
-    print(f"\nAgent: {reply}")
+    print("=" * 60)
+    print("完整记忆 Agent（交互式）")
+    print("=" * 60)
+    print("输入 'quit' 或 '退出' 结束对话")
+    print("输入 '/memory' 查看当前记忆库")
+    print("输入 '/clear' 清空记忆库（重新开始）")
     print()
+    show_memory_stats()
+    print()
+
+    while True:
+        try:
+            user_input = input("你: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print("\n再见！")
+            break
+
+        if not user_input:
+            continue
+        if user_input.lower() in ["quit", "exit", "退出"]:
+            print("再见！记忆已保存，下次启动时会自动加载。")
+            break
+        if user_input == "/memory":
+            show_memory_stats()
+            continue
+        if user_input == "/clear":
+            db.delete_collection(MEMORY_COLLECTION)
+            memory_col = db.create_collection(name=MEMORY_COLLECTION)
+            print("  [记忆库] 已清空")
+            continue
+
+        print()
+        reply = chat(user_input, verbose=True)
+        print(f"\nAgent: {reply}")
+        print()
+
+
+def main():
+    initialize_runtime()
+    run_interactive()
+
+
+if __name__ == "__main__":
+    main()

--- a/code/D4/d4_5_multi_user_isolation.py
+++ b/code/D4/d4_5_multi_user_isolation.py
@@ -22,9 +22,11 @@ d4_5：多用户 / 多租户记忆隔离
 
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
+from uuid import uuid4
 
 
 # ---------- 1. 数据模型 ----------
@@ -55,7 +57,6 @@ class IsolatedMemoryStore:
 
     def __init__(self) -> None:
         self._store: list[MemoryRecord] = []
-        self._seq = 0
 
     def add(
         self,
@@ -68,16 +69,15 @@ class IsolatedMemoryStore:
         if not user_id:
             raise ValueError("user_id is required for multi-tenant isolation")
 
-        self._seq += 1
         record = MemoryRecord(
-            id=f"mem_{self._seq:03d}",
+            id=str(uuid4()),
             content=content,
             user_id=user_id,
             agent_id=agent_id,
             run_id=run_id,
         )
         self._store.append(record)
-        return record
+        return deepcopy(record)
 
     def search(
         self,
@@ -111,9 +111,23 @@ class IsolatedMemoryStore:
                 results.append((score, mem))
 
         results.sort(key=lambda item: item[0], reverse=True)
-        return [mem for _, mem in results]
+        return [deepcopy(mem) for _, mem in results]
 
-    def get(self, memory_id: str) -> MemoryRecord | None:
+    def get(self, memory_id: str, requester_id: str) -> MemoryRecord | None:
+        """按请求者身份读取记忆；返回副本，防止绕过更新权限修改内部状态。"""
+        if not requester_id:
+            raise ValueError("requester_id is required for memory reads")
+        mem = self._find(memory_id)
+        if mem is None:
+            return None
+        if not self.check_permission(memory_id, requester_id, "read"):
+            raise PermissionError(
+                f"User {requester_id} cannot read memory owned by {mem.user_id}"
+            )
+        return deepcopy(mem)
+
+    def _find(self, memory_id: str) -> MemoryRecord | None:
+        """内部查找返回存储对象，仅供已执行权限检查的写路径使用。"""
         for mem in self._store:
             if mem.id == memory_id:
                 return mem
@@ -126,7 +140,7 @@ class IsolatedMemoryStore:
         permission: str,
     ) -> bool:
         """检查 requester 对某条记忆是否具备指定权限"""
-        mem = self.get(memory_id)
+        mem = self._find(memory_id)
         if mem is None:
             return False
         if mem.user_id == requester_id:
@@ -165,7 +179,7 @@ class IsolatedMemoryStore:
         new_content: str,
     ) -> dict[str, Any]:
         """更新记忆：所有者，或被授予 write 的用户"""
-        mem = self.get(memory_id)
+        mem = self._find(memory_id)
         if mem is None:
             raise ValueError(f"Memory {memory_id} not found")
 
@@ -187,20 +201,30 @@ class IsolatedMemoryStore:
             "deleted_by": requester_id,
         }
 
-    def get_all_for_user(self, user_id: str) -> list[MemoryRecord]:
-        """调试用：列出某用户命名空间内的全部记忆"""
-        return [mem for mem in self._store if mem.user_id == user_id]
+    def get_all_for_user(
+        self,
+        user_id: str,
+        requester_id: str,
+    ) -> list[MemoryRecord]:
+        """列出用户命名空间；请求者只能读取自己的全部记忆。"""
+        if not user_id or not requester_id:
+            raise ValueError("user_id and requester_id are required for memory reads")
+        if requester_id != user_id:
+            raise PermissionError(
+                f"User {requester_id} cannot list memories owned by {user_id}"
+            )
+        return [deepcopy(mem) for mem in self._store if mem.user_id == user_id]
 
     def search_without_isolation(self, query: str) -> list[MemoryRecord]:
         """反例：去掉 user_id 过滤，演示串户风险（仅用于对比，生产禁用）"""
         keywords = [kw for kw in query.lower().split() if kw]
         return [
-            mem for mem in self._store
+            deepcopy(mem) for mem in self._store
             if self._relevance(mem.content, keywords) > 0
         ]
 
     def _require_owned(self, memory_id: str, requester_id: str) -> MemoryRecord:
-        mem = self.get(memory_id)
+        mem = self._find(memory_id)
         if mem is None:
             raise ValueError(f"Memory {memory_id} not found")
         if mem.user_id != requester_id:
@@ -295,14 +319,14 @@ def demo_permission_guard(
         print(f"  PermissionError → {exc}")
         print("  → 正确：非所有者删除被拒绝")
 
-    still_there = store.get(target.id)
+    still_there = store.get(target.id, requester_id="alice")
     assert still_there is not None, "memory should still exist after denied delete"
     print(f"  记忆仍在：[{still_there.id}]")
 
     print("\n[合法] Alice 删除自己的一条记忆")
     result = store.delete(target.id, requester_id="alice")
     print(f"  删除成功：{result}")
-    assert store.get(target.id) is None
+    assert store.get(target.id, requester_id="alice") is None
 
 
 def demo_explicit_share(
@@ -355,7 +379,7 @@ def print_summary(store: IsolatedMemoryStore) -> None:
     print("当前各用户命名空间快照")
     print("=" * 64)
     for user_id in ("alice", "bob"):
-        memories = store.get_all_for_user(user_id)
+        memories = store.get_all_for_user(user_id, requester_id=user_id)
         print(f"\n  [{user_id}] 共 {len(memories)} 条")
         for mem in memories:
             shared = (

--- a/code/D4/d4_6_memory_compression.py
+++ b/code/D4/d4_6_memory_compression.py
@@ -160,11 +160,20 @@ class FactMemoryStore:
         selected = self.facts[:k]
         return sum(estimate_tokens(item) for item in selected)
 
-    def consolidate_topic(self, topic_keywords: list[str], min_count: int = 3) -> str | None:
+    def consolidate_topic(
+        self,
+        topic_keywords: list[str],
+        distilled_fact: str,
+        min_count: int = 3,
+    ) -> str | None:
         """
         把同一话题下的多条碎片记忆，蒸馏成一条稳定事实。
         对应课程伪代码 consolidate_topic。
         """
+        if not isinstance(distilled_fact, str) or not distilled_fact.strip():
+            raise ValueError("distilled_fact must be a non-empty explicit fact")
+        distilled_fact = distilled_fact.strip()
+
         matched = [
             fact for fact in self.facts
             if any(kw.lower() in fact.lower() for kw in topic_keywords)
@@ -172,13 +181,12 @@ class FactMemoryStore:
         if len(matched) < min_count:
             return None
 
-        distilled = "用户后端已从 Flask 迁移到 FastAPI"
         # 碎片移出检索面，只保留稳定事实
         self.archived_fragments.extend(matched)
         self.facts = [fact for fact in self.facts if fact not in matched]
-        if distilled not in self.facts:
-            self.facts.insert(0, distilled)
-        return distilled
+        if distilled_fact not in self.facts:
+            self.facts.insert(0, distilled_fact)
+        return distilled_fact
 
 
 @dataclass
@@ -260,6 +268,7 @@ def demo_consolidation(fact_store: FactMemoryStore) -> None:
     distilled = fact_store.consolidate_topic(
         # 只聚合成“迁移”话题，避免把 Redis 等长尾事实误归档
         topic_keywords=["Flask", "偏慢", "迁移到 FastAPI", "切到 FastAPI"],
+        distilled_fact="用户后端已从 Flask 迁移到 FastAPI",
         min_count=3,
     )
     print(f"  蒸馏结果：{distilled}")

--- a/code/D4/d4_7_hot_cold_tier.py
+++ b/code/D4/d4_7_hot_cold_tier.py
@@ -19,6 +19,8 @@ d4_7：长期记忆冷热分层
 from __future__ import annotations
 
 import math
+import uuid
+from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -50,8 +52,6 @@ class TieredMemoryStore:
 
     memories: dict[str, TieredMemory] = field(default_factory=dict)
     archive: dict[str, TieredMemory] = field(default_factory=dict)
-    _seq: int = 0
-
     def add(
         self,
         content: str,
@@ -60,9 +60,8 @@ class TieredMemoryStore:
         days_since_access: int,
         is_profile: bool = False,
     ) -> TieredMemory:
-        self._seq += 1
         mem = TieredMemory(
-            id=f"mem_{self._seq:03d}",
+            id=str(uuid.uuid4()),
             content=content,
             user_id=user_id,
             retention=retention,
@@ -75,9 +74,23 @@ class TieredMemoryStore:
             self.archive[mem.id] = mem
         else:
             self.memories[mem.id] = mem
-        return mem
+        return deepcopy(mem)
 
-    def get(self, memory_id: str) -> TieredMemory | None:
+    def get(self, memory_id: str, requester_id: str) -> TieredMemory | None:
+        """仅所有者可按 ID 读取；返回副本，避免绕过迁移规则修改存储。"""
+        if not requester_id:
+            raise ValueError("requester_id is required for memory reads")
+        mem = self._find(memory_id)
+        if mem is None:
+            return None
+        if mem.user_id != requester_id:
+            raise PermissionError(
+                f"User {requester_id} cannot read memory owned by {mem.user_id}"
+            )
+        return deepcopy(mem)
+
+    def _find(self, memory_id: str) -> TieredMemory | None:
+        """内部迁移路径使用的存储对象查找。"""
         return self.memories.get(memory_id) or self.archive.get(memory_id)
 
     def search(self, query: str, user_id: str, include_cold: bool = False) -> list[TieredMemory]:
@@ -98,7 +111,7 @@ class TieredMemoryStore:
                 hits.append((score, mem))
 
         hits.sort(key=lambda item: item[0], reverse=True)
-        return [mem for _, mem in hits]
+        return [deepcopy(mem) for _, mem in hits]
 
     def archive_memory(self, memory_id: str) -> None:
         mem = self.memories.pop(memory_id, None)
@@ -109,7 +122,7 @@ class TieredMemoryStore:
         self.archive[memory_id] = mem
 
     def drop_from_hot_index(self, memory_id: str) -> None:
-        mem = self.get(memory_id)
+        mem = self._find(memory_id)
         if mem is not None:
             mem.in_hot_index = False
 
@@ -144,26 +157,32 @@ def assign_tier(memory: TieredMemory, retention: float, days_since_access: int) 
 
 
 def migrate_if_needed(store: TieredMemoryStore, memory: TieredMemory) -> str | None:
-    """分层变化时迁移：降温归档 / 回热唤醒"""
-    new_tier = assign_tier(memory, memory.retention, memory.days_since_access)
-    if new_tier == memory.tier:
+    """受控同步新指标，并在存储内部原子完成分层迁移。"""
+    stored = store._find(memory.id)
+    if stored is None:
         return None
 
-    old_tier = memory.tier
-    if new_tier == "cold":
-        store.archive_memory(memory.id)
-        store.drop_from_hot_index(memory.id)
-    elif new_tier == "hot":
-        store.restore_to_hot(memory.id)
-    else:
-        # warm：仍留在线库，但标记层级
-        if memory.id in store.archive:
-            store.restore_to_hot(memory.id)
-        memory = store.get(memory.id)
-        assert memory is not None
-        memory.tier = "warm"
-        memory.in_hot_index = True
+    new_retention = memory.retention
+    new_days_since_access = memory.days_since_access
+    new_tier = assign_tier(stored, new_retention, new_days_since_access)
+    old_tier = stored.tier
 
+    # 只同步分层决策允许更新的字段，不接受副本修改所有者或画像标记。
+    stored.retention = new_retention
+    stored.days_since_access = new_days_since_access
+    if new_tier == old_tier:
+        return None
+
+    if new_tier == "cold":
+        store.memories.pop(stored.id, None)
+        store.archive[stored.id] = stored
+        stored.in_hot_index = False
+    else:
+        store.archive.pop(stored.id, None)
+        store.memories[stored.id] = stored
+        stored.in_hot_index = True
+
+    stored.tier = new_tier
     return f"{old_tier} -> {new_tier}"
 
 

--- a/code/D4/d4_8_memory_cleanup.py
+++ b/code/D4/d4_8_memory_cleanup.py
@@ -19,6 +19,8 @@ d4_8：长期记忆定期清理
 from __future__ import annotations
 
 import math
+import uuid
+from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Any, Iterator
@@ -49,8 +51,6 @@ class LifecycleMemoryStore:
     vector_index: set[str] = field(default_factory=set)
     cache: dict[str, str] = field(default_factory=dict)
     archive: dict[str, MemoryItem] = field(default_factory=dict)
-    _seq: int = 0
-
     def add(
         self,
         content: str,
@@ -61,8 +61,7 @@ class LifecycleMemoryStore:
         access_count: int = 0,
         protected: bool = False,
     ) -> MemoryItem:
-        self._seq += 1
-        mem_id = f"mem_{self._seq:03d}"
+        mem_id = str(uuid.uuid4())
         item = MemoryItem(
             id=mem_id,
             content=content,
@@ -75,12 +74,15 @@ class LifecycleMemoryStore:
         self.records[mem_id] = item
         self.vector_index.add(mem_id)
         self.cache[mem_id] = content
-        return item
+        return deepcopy(item)
 
-    def iter_all(self, user_id: str | None = None) -> Iterator[MemoryItem]:
+    def iter_all(self, user_id: str) -> Iterator[MemoryItem]:
+        """按用户范围读取生命周期记忆，并返回副本。"""
+        if not user_id or not user_id.strip():
+            raise ValueError("user_id is required for memory reads")
         for item in self.records.values():
-            if user_id is None or item.user_id == user_id:
-                yield item
+            if item.user_id == user_id:
+                yield deepcopy(item)
 
     def archive_memory(self, memory_id: str) -> None:
         item = self.records.get(memory_id)
@@ -94,12 +96,25 @@ class LifecycleMemoryStore:
         self.vector_index.discard(memory_id)
         self.cache.pop(memory_id, None)
 
-    def delete(self, memory_id: str) -> None:
-        """级联清理：主库 + 向量 + 缓存 + 归档副本"""
+    def delete(self, memory_id: str, requester_id: str) -> bool:
+        """仅所有者可硬删；受保护记忆只能归档，不能直接删除。"""
+        if not requester_id or not requester_id.strip():
+            raise ValueError("requester_id is required for memory deletion")
+        item = self.records.get(memory_id)
+        if item is None:
+            return False
+        if item.user_id != requester_id:
+            raise PermissionError(
+                f"User {requester_id} cannot delete memory owned by {item.user_id}"
+            )
+        if item.protected:
+            raise PermissionError(f"Protected memory {memory_id} cannot be deleted")
+
         self.records.pop(memory_id, None)
         self.archive.pop(memory_id, None)
         self.vector_index.discard(memory_id)
         self.cache.pop(memory_id, None)
+        return True
 
     def searchable_ids(self) -> set[str]:
         return set(self.vector_index)
@@ -124,13 +139,16 @@ def cleanup_memories(
     store: LifecycleMemoryStore,
     now: datetime,
     *,
-    user_id: str | None = None,
+    user_id: str,
     dry_run: bool = True,
 ) -> dict[str, Any]:
     """
     定期清理作业。
     dry_run=True 时只统计将要发生的动作，便于先观测再真正删除。
     """
+    if not user_id or not user_id.strip():
+        raise ValueError("user_id is required for scoped memory cleanup")
+
     stats = {"archived": 0, "deleted": 0, "kept": 0, "protected_skipped": 0}
     actions: list[str] = []
 
@@ -147,7 +165,7 @@ def cleanup_memories(
             stats["deleted"] += 1
             actions.append(f"DELETE {mem.id} R={retention:.2f} idle={idle_days}d")
             if not dry_run:
-                store.delete(mem.id)
+                store.delete(mem.id, requester_id=user_id)
             continue
 
         # 保护字段若已达硬删条件：跳过删除，最多归档
@@ -309,14 +327,15 @@ def main() -> None:
     store = seed_store(now)
 
     print(">>> 已写入 Alice / Bob 的生命周期样例记忆")
-    for item in store.iter_all():
-        r = calc_retention(item, now)
-        idle = (now - item.last_accessed_at).days
-        flag = "protected" if item.protected else "normal"
-        print(
-            f"    [{item.id}] ({item.user_id}) R={r:.2f} idle={idle}d "
-            f"{flag} | {item.content}"
-        )
+    for user_id in ("alice", "bob"):
+        for item in store.iter_all(user_id=user_id):
+            r = calc_retention(item, now)
+            idle = (now - item.last_accessed_at).days
+            flag = "protected" if item.protected else "normal"
+            print(
+                f"    [{item.id}] ({item.user_id}) R={r:.2f} idle={idle}d "
+                f"{flag} | {item.content}"
+            )
 
     demo_dry_run(store, now)
     demo_apply_cleanup(store, now)

--- a/code/D4/test_d4_memory_security.py
+++ b/code/D4/test_d4_memory_security.py
@@ -1,0 +1,653 @@
+import ast
+import contextlib
+import io
+import json
+import runpy
+import time
+import unittest
+import uuid
+from datetime import datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from d4_5_multi_user_isolation import IsolatedMemoryStore
+from d4_6_memory_compression import FactMemoryStore
+from d4_7_hot_cold_tier import TieredMemoryStore, migrate_if_needed
+from d4_8_memory_cleanup import LifecycleMemoryStore, cleanup_memories
+
+
+D4_DIR = Path(__file__).resolve().parent
+
+
+def load_functions(file_name: str) -> dict:
+    """只加载示例中的函数定义，避免测试触发真实模型或数据库初始化。"""
+    source_path = D4_DIR / file_name
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    function_nodes = [
+        node for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ]
+    module = ast.Module(body=function_nodes, type_ignores=[])
+    namespace = {
+        "json": json,
+        "time": time,
+        "uuid": uuid,
+    }
+    exec(compile(module, str(source_path), "exec"), namespace)
+    return namespace
+
+
+class FakeCollection:
+    def __init__(self) -> None:
+        self.ids: list[str] = []
+
+    def add(self, *, ids, documents, metadatas) -> None:
+        self.ids.extend(ids)
+
+    def count(self) -> int:
+        return len(self.ids)
+
+
+class FakeCompletions:
+    def __init__(self, responses) -> None:
+        self.responses = list(responses)
+
+    def create(self, **kwargs):
+        return self.responses.pop(0)
+
+
+def fake_client(*responses):
+    return SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=FakeCompletions(responses),
+        )
+    )
+
+
+def response_with(message=None, *, choices=True):
+    if not choices:
+        return SimpleNamespace(choices=[])
+    return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+
+def plain_message(content: str | None):
+    return SimpleNamespace(content=content, tool_calls=None)
+
+
+def tool_message(name: str, arguments: str):
+    call = SimpleNamespace(
+        id="call-1",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+    return SimpleNamespace(content=None, tool_calls=[call])
+
+
+def tool_batch_message(*calls):
+    return SimpleNamespace(
+        content=None,
+        tool_calls=[
+            SimpleNamespace(
+                id=f"call-{index}",
+                function=SimpleNamespace(name=name, arguments=arguments),
+            )
+            for index, (name, arguments) in enumerate(calls, start=1)
+        ],
+    )
+
+
+class MemoryIdSecurityTests(unittest.TestCase):
+    def test_all_d4_memory_stores_generate_uuid4_ids(self):
+        generated_ids: list[str] = []
+
+        for file_name, function_name in (
+            ("d4_3_with_memory.py", "add_memory"),
+            ("d4_4_memory_agent.py", "save_memory"),
+        ):
+            with self.subTest(file_name=file_name):
+                namespace = load_functions(file_name)
+                collection = FakeCollection()
+                namespace["memory_col"] = collection
+                namespace[function_name](["用户偏好简洁回答", "用户是 Python 开发者"])
+                generated_ids.extend(collection.ids)
+
+        isolated = IsolatedMemoryStore()
+        generated_ids.append(isolated.add("事实", user_id="alice").id)
+
+        tiered = TieredMemoryStore()
+        generated_ids.append(
+            tiered.add(
+                "事实",
+                user_id="alice",
+                retention=0.9,
+                days_since_access=1,
+            ).id
+        )
+
+        lifecycle = LifecycleMemoryStore()
+        generated_ids.append(
+            lifecycle.add(
+                "事实",
+                user_id="alice",
+                created_at=datetime(2026, 7, 28, 12, 0, 0),
+            ).id
+        )
+
+        self.assertEqual(len(generated_ids), len(set(generated_ids)))
+        for memory_id in generated_ids:
+            parsed = uuid.UUID(memory_id)
+            self.assertEqual(parsed.version, 4)
+
+
+class ExternalInitializationSafetyTests(unittest.TestCase):
+    def test_importing_database_examples_has_no_external_side_effects(self):
+        for file_name in ("d4_3_with_memory.py", "d4_4_memory_agent.py"):
+            with self.subTest(file_name=file_name):
+                with (
+                    patch("openai.OpenAI", side_effect=AssertionError("导入时不应创建模型客户端")),
+                    patch("pyseekdb.Client", side_effect=AssertionError("导入时不应打开数据库")),
+                    contextlib.redirect_stdout(io.StringIO()),
+                ):
+                    namespace = runpy.run_path(
+                        str(D4_DIR / file_name),
+                        run_name=f"d4_import_test_{file_name}",
+                    )
+
+                self.assertIsNone(namespace["client"])
+                self.assertIsNone(namespace["db"])
+                self.assertIsNone(namespace["memory_col"])
+
+    def test_memory_database_paths_are_anchored_to_script_directory(self):
+        expected_paths = {
+            "d4_3_with_memory.py": D4_DIR / "memory.db",
+            "d4_4_memory_agent.py": D4_DIR / "memory_persistent.db",
+        }
+
+        for file_name, expected_path in expected_paths.items():
+            with self.subTest(file_name=file_name):
+                with (
+                    patch("openai.OpenAI", side_effect=AssertionError("导入时不应创建模型客户端")),
+                    patch("pyseekdb.Client", side_effect=AssertionError("导入时不应打开数据库")),
+                    contextlib.redirect_stdout(io.StringIO()),
+                ):
+                    namespace = runpy.run_path(
+                        str(D4_DIR / file_name),
+                        run_name=f"d4_path_test_{file_name}",
+                    )
+                self.assertEqual(namespace["MEMORY_DB_PATH"], expected_path)
+
+    def test_explicit_initialization_accepts_injected_client_and_database(self):
+        class FakeDatabase:
+            def __init__(self, *, exists: bool) -> None:
+                self.exists = exists
+                self.collection = FakeCollection()
+                self.calls: list[str] = []
+
+            def has_collection(self, name: str) -> bool:
+                self.calls.append(f"has:{name}")
+                return self.exists
+
+            def delete_collection(self, name: str) -> None:
+                self.calls.append(f"delete:{name}")
+
+            def create_collection(self, name: str):
+                self.calls.append(f"create:{name}")
+                return self.collection
+
+            def get_collection(self, name: str):
+                self.calls.append(f"get:{name}")
+                return self.collection
+
+        cases = (
+            (
+                "d4_3_with_memory.py",
+                True,
+                [
+                    "has:user_memory_demo",
+                    "delete:user_memory_demo",
+                    "create:user_memory_demo",
+                ],
+            ),
+            (
+                "d4_4_memory_agent.py",
+                True,
+                [
+                    "has:user_memory_persistent",
+                    "get:user_memory_persistent",
+                ],
+            ),
+        )
+
+        for file_name, exists, expected_calls in cases:
+            with self.subTest(file_name=file_name):
+                with (
+                    patch("openai.OpenAI", side_effect=AssertionError("导入时不应创建模型客户端")),
+                    patch("pyseekdb.Client", side_effect=AssertionError("导入时不应打开数据库")),
+                    contextlib.redirect_stdout(io.StringIO()),
+                ):
+                    namespace = runpy.run_path(
+                        str(D4_DIR / file_name),
+                        run_name=f"d4_init_test_{file_name}",
+                    )
+                    model_client = object()
+                    database = FakeDatabase(exists=exists)
+                    collection = namespace["initialize_runtime"](
+                        api_client=model_client,
+                        database=database,
+                    )
+
+                runtime_globals = namespace["initialize_runtime"].__globals__
+                self.assertIs(runtime_globals["client"], model_client)
+                self.assertIs(runtime_globals["db"], database)
+                self.assertIs(runtime_globals["memory_col"], collection)
+                self.assertEqual(database.calls, expected_calls)
+
+
+class IsolatedReadSecurityTests(unittest.TestCase):
+    def test_add_returns_copy_that_cannot_change_owner(self):
+        store = IsolatedMemoryStore()
+        created = store.add("Alice 的私密事实", user_id="alice")
+        created.user_id = "bob"
+        created.shared_with["bob"] = ["write"]
+
+        with self.assertRaises(PermissionError):
+            store.delete(created.id, requester_id="bob")
+
+        fresh = store.get(created.id, requester_id="alice")
+        self.assertEqual(fresh.user_id, "alice")
+        self.assertEqual(fresh.shared_with, {})
+
+    def test_get_requires_authorized_requester_and_returns_deep_copy(self):
+        store = IsolatedMemoryStore()
+        created = store.add("Alice 的私密事实", user_id="alice")
+
+        with self.assertRaises(TypeError):
+            store.get(created.id)
+        with self.assertRaises(PermissionError):
+            store.get(created.id, requester_id="bob")
+
+        owner_copy = store.get(created.id, requester_id="alice")
+        self.assertIsNotNone(owner_copy)
+        owner_copy.content = "被外部篡改"
+        owner_copy.shared_with["bob"] = ["write"]
+
+        fresh_copy = store.get(created.id, requester_id="alice")
+        self.assertEqual(fresh_copy.content, "Alice 的私密事实")
+        self.assertEqual(fresh_copy.shared_with, {})
+
+    def test_search_and_user_listing_return_defensive_copies(self):
+        store = IsolatedMemoryStore()
+        created = store.add("Alice 使用 Python", user_id="alice")
+
+        search_copy = store.search("Python", user_id="alice")[0]
+        search_copy.content = "搜索结果被篡改"
+
+        listing_copy = store.get_all_for_user(
+            "alice",
+            requester_id="alice",
+        )[0]
+        listing_copy.content = "列表结果被篡改"
+
+        fresh_copy = store.get(created.id, requester_id="alice")
+        self.assertEqual(fresh_copy.content, "Alice 使用 Python")
+
+    def test_user_listing_requires_matching_requester(self):
+        store = IsolatedMemoryStore()
+        store.add("Alice 的私密事实", user_id="alice")
+
+        with self.assertRaises(TypeError):
+            store.get_all_for_user("alice")
+
+        try:
+            store.get_all_for_user("alice", requester_id="bob")
+        except Exception as exc:
+            self.assertIsInstance(exc, PermissionError)
+        else:
+            self.fail("cross-user listing must be denied")
+
+    def test_insecure_search_demo_returns_deep_copies(self):
+        store = IsolatedMemoryStore()
+        created = store.add("Alice 对花生过敏", user_id="alice")
+
+        leaked_copy = store.search_without_isolation("花生 过敏")[0]
+        leaked_copy.content = "反例读取结果被篡改"
+        leaked_copy.shared_with["mallory"] = ["write"]
+
+        fresh_copy = store.get(created.id, requester_id="alice")
+        self.assertEqual(fresh_copy.content, "Alice 对花生过敏")
+        self.assertEqual(fresh_copy.shared_with, {})
+
+
+class TieredAndLifecycleReadSecurityTests(unittest.TestCase):
+    def test_tiered_migration_atomically_syncs_copy_metrics(self):
+        store = TieredMemoryStore()
+        memory = store.add(
+            "Alice 的温层事实",
+            user_id="alice",
+            retention=0.5,
+            days_since_access=20,
+        )
+        self.assertEqual(memory.tier, "warm")
+
+        memory.retention = 0.2
+        memory.days_since_access = 45
+        moved = migrate_if_needed(store, memory)
+
+        self.assertEqual(moved, "warm -> cold")
+        archived = store.archive[memory.id]
+        self.assertEqual(archived.tier, "cold")
+        self.assertEqual(archived.retention, 0.2)
+        self.assertEqual(archived.days_since_access, 45)
+        self.assertFalse(archived.in_hot_index)
+
+    def test_tiered_add_returns_copy_that_cannot_change_owner(self):
+        store = TieredMemoryStore()
+        created = store.add(
+            "Alice 使用 Python",
+            user_id="alice",
+            retention=0.9,
+            days_since_access=1,
+        )
+        created.user_id = "bob"
+        created.retention = 0.0
+
+        with self.assertRaises(PermissionError):
+            store.get(created.id, requester_id="bob")
+
+        fresh = store.get(created.id, requester_id="alice")
+        self.assertEqual(fresh.user_id, "alice")
+        self.assertEqual(fresh.retention, 0.9)
+
+    def test_lifecycle_add_copy_cannot_disable_protection(self):
+        now = datetime(2026, 7, 28, 12, 0, 0)
+        store = LifecycleMemoryStore()
+        created = store.add(
+            "primary_language=Python",
+            user_id="alice",
+            created_at=now,
+            protected=True,
+        )
+        created.protected = False
+
+        with self.assertRaises(PermissionError):
+            store.delete(created.id, requester_id="alice")
+
+        self.assertTrue(store.records[created.id].protected)
+
+    def test_tiered_get_requires_owner_and_read_results_are_copies(self):
+        store = TieredMemoryStore()
+        created = store.add(
+            "Alice 使用 Python",
+            user_id="alice",
+            retention=0.9,
+            days_since_access=1,
+        )
+
+        with self.assertRaises(PermissionError):
+            store.get(created.id, requester_id="bob")
+
+        get_copy = store.get(created.id, requester_id="alice")
+        get_copy.content = "按 ID 读取结果被篡改"
+
+        search_copy = store.search("Python", user_id="alice")[0]
+        search_copy.content = "搜索结果被篡改"
+
+        fresh_copy = store.get(created.id, requester_id="alice")
+        self.assertEqual(fresh_copy.content, "Alice 使用 Python")
+
+    def test_lifecycle_iteration_requires_user_and_returns_copies(self):
+        store = LifecycleMemoryStore()
+        created = store.add(
+            "Alice 的生命周期事实",
+            user_id="alice",
+            created_at=datetime(2026, 7, 28, 12, 0, 0),
+        )
+
+        with self.assertRaises(TypeError):
+            list(store.iter_all())
+
+        item_copy = list(store.iter_all(user_id="alice"))[0]
+        item_copy.content = "遍历结果被篡改"
+
+        self.assertEqual(store.records[created.id].content, "Alice 的生命周期事实")
+
+
+class DistillationSecurityTests(unittest.TestCase):
+    def test_consolidation_requires_explicit_non_empty_fact(self):
+        store = FactMemoryStore(
+            facts=[
+                "用户认为 Flask 偏慢",
+                "用户准备迁移到 FastAPI",
+                "用户后端已切到 FastAPI",
+            ]
+        )
+
+        with self.assertRaises(TypeError):
+            store.consolidate_topic(["Flask", "FastAPI"], min_count=3)
+        with self.assertRaises(ValueError):
+            store.consolidate_topic(
+                ["Flask", "FastAPI"],
+                distilled_fact="   ",
+                min_count=3,
+            )
+
+    def test_consolidation_uses_the_caller_provided_fact(self):
+        store = FactMemoryStore(
+            facts=[
+                "用户认为 Flask 偏慢",
+                "用户准备迁移到 FastAPI",
+                "用户后端已切到 FastAPI",
+            ]
+        )
+
+        distilled = store.consolidate_topic(
+            ["Flask", "FastAPI"],
+            distilled_fact="用户已完成 Web 框架迁移",
+            min_count=3,
+        )
+
+        self.assertEqual(distilled, "用户已完成 Web 框架迁移")
+        self.assertEqual(store.facts, ["用户已完成 Web 框架迁移"])
+
+
+class CleanupSecurityTests(unittest.TestCase):
+    def test_cleanup_requires_non_empty_user_id(self):
+        now = datetime(2026, 7, 28, 12, 0, 0)
+        store = LifecycleMemoryStore()
+        store.add(
+            "过期事实",
+            user_id="alice",
+            created_at=now - timedelta(days=200),
+            last_accessed_at=now - timedelta(days=150),
+        )
+
+        with self.assertRaises(TypeError):
+            cleanup_memories(store, now)
+        with self.assertRaises(ValueError):
+            cleanup_memories(store, now, user_id="   ")
+
+    def test_direct_delete_checks_owner_and_protected_flag(self):
+        now = datetime(2026, 7, 28, 12, 0, 0)
+        store = LifecycleMemoryStore()
+        protected = store.add(
+            "primary_language=Python",
+            user_id="alice",
+            created_at=now - timedelta(days=200),
+            protected=True,
+        )
+
+        with self.assertRaises(PermissionError):
+            store.delete(protected.id, requester_id="bob")
+        with self.assertRaises(PermissionError):
+            store.delete(protected.id, requester_id="alice")
+
+        self.assertIn(protected.id, store.records)
+        self.assertIn(protected.id, store.vector_index)
+
+    def test_cleanup_only_changes_the_requested_user(self):
+        now = datetime(2026, 7, 28, 12, 0, 0)
+        store = LifecycleMemoryStore()
+        alice = store.add(
+            "Alice 的过期事实",
+            user_id="alice",
+            created_at=now - timedelta(days=200),
+            last_accessed_at=now - timedelta(days=150),
+        )
+        bob = store.add(
+            "Bob 的过期事实",
+            user_id="bob",
+            created_at=now - timedelta(days=200),
+            last_accessed_at=now - timedelta(days=150),
+        )
+
+        cleanup_memories(store, now, user_id="alice", dry_run=False)
+
+        self.assertNotIn(alice.id, store.records)
+        self.assertIn(bob.id, store.records)
+
+
+class ToolCallSecurityTests(unittest.TestCase):
+    def setUp(self):
+        self.namespace = load_functions("d4_1_react_loop.py")
+        self.namespace["MODEL"] = "offline-test-model"
+        self.namespace["tools"] = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "safe_tool",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"value": {"type": "string"}},
+                        "required": ["value"],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                },
+            },
+        ]
+
+    def test_unknown_tool_name_is_rejected_before_execution(self):
+        executed: list[str] = []
+        self.namespace["tool_functions"] = {
+            "safe_tool": lambda args: executed.append("safe") or "ok",
+        }
+        self.namespace["client"] = fake_client(
+            response_with(tool_message("delete_everything", "{}")),
+        )
+
+        with self.assertRaisesRegex(ValueError, "未注册"):
+            self.namespace["agent_loop"]("问题")
+
+        self.assertEqual(executed, [])
+
+    def test_entire_tool_batch_is_validated_before_any_execution(self):
+        executed: list[str] = []
+        self.namespace["tool_functions"] = {
+            "safe_tool": lambda args: executed.append("safe") or "ok",
+        }
+        self.namespace["client"] = fake_client(
+            response_with(
+                tool_batch_message(
+                    ("safe_tool", '{"value": "ok"}'),
+                    ("delete_everything", "{}"),
+                )
+            ),
+        )
+
+        with self.assertRaisesRegex(ValueError, "未注册"):
+            self.namespace["agent_loop"]("问题")
+
+        self.assertEqual(executed, [])
+
+    def test_malformed_or_non_object_json_arguments_are_rejected(self):
+        for arguments in ('{"city":', '["北京"]'):
+            with self.subTest(arguments=arguments):
+                executed: list[str] = []
+                self.namespace["tool_functions"] = {
+                    "get_weather": lambda args: executed.append("called") or "ok",
+                }
+                self.namespace["client"] = fake_client(
+                    response_with(tool_message("get_weather", arguments)),
+                    response_with(plain_message("不会执行到这里")),
+                )
+
+                with self.assertRaisesRegex(ValueError, "JSON|对象"):
+                    self.namespace["agent_loop"]("问题")
+
+                self.assertEqual(executed, [])
+
+    def test_missing_or_non_string_required_arguments_are_rejected_before_execution(self):
+        for arguments in ("{}", '{"city": 42}'):
+            with self.subTest(arguments=arguments):
+                executed: list[str] = []
+                self.namespace["tool_functions"] = {
+                    "get_weather": lambda args: executed.append("called") or "ok",
+                }
+                self.namespace["client"] = fake_client(
+                    response_with(tool_message("get_weather", arguments)),
+                )
+
+                with self.assertRaisesRegex(ValueError, "必填|字符串"):
+                    self.namespace["agent_loop"]("问题")
+
+                self.assertEqual(executed, [])
+
+    def test_invalid_later_arguments_prevent_entire_batch_execution(self):
+        executed: list[str] = []
+        self.namespace["tool_functions"] = {
+            "safe_tool": lambda args: executed.append("safe") or "ok",
+            "get_weather": lambda args: executed.append("weather") or "ok",
+        }
+        self.namespace["client"] = fake_client(
+            response_with(
+                tool_batch_message(
+                    ("safe_tool", '{"value": "ok"}'),
+                    ("get_weather", "{}"),
+                )
+            ),
+            response_with(plain_message("不会执行到这里")),
+        )
+
+        with self.assertRaisesRegex(ValueError, "必填"):
+            self.namespace["agent_loop"]("问题")
+
+        self.assertEqual(executed, [])
+
+    def test_empty_or_contentless_model_response_is_rejected(self):
+        self.namespace["tool_functions"] = {}
+
+        for response in (
+            response_with(choices=False),
+            response_with(None),
+            response_with(plain_message(None)),
+        ):
+            with self.subTest(response=response):
+                self.namespace["client"] = fake_client(response)
+                with self.assertRaisesRegex(RuntimeError, "空响应"):
+                    self.namespace["agent_loop"]("问题")
+
+    def test_valid_tool_call_still_returns_final_answer(self):
+        self.namespace["tool_functions"] = {
+            "get_weather": lambda args: f"{args['city']}：晴",
+        }
+        self.namespace["client"] = fake_client(
+            response_with(tool_message("get_weather", '{"city": "北京"}')),
+            response_with(plain_message("北京今天晴。")),
+        )
+
+        answer = self.namespace["agent_loop"]("北京天气？")
+
+        self.assertEqual(answer, "北京今天晴。")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/P5/README.md
+++ b/code/P5/README.md
@@ -102,8 +102,11 @@ uvicorn app.main:app --host 0.0.0.0 --port 8000
 
 ```bash
 cd code/P5
-docker compose up --build
+GRAFANA_ADMIN_PASSWORD='请替换为本地强密码' docker compose up --build
 ```
+
+`GRAFANA_ADMIN_PASSWORD` 必须显式提供；可选设置 `GRAFANA_ADMIN_USER`，
+未设置用户名时默认为 `admin`。匿名访问仍限制为只读 `Viewer`。
 
 启动后访问：
 

--- a/code/P5/app/main.py
+++ b/code/P5/app/main.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from fastapi import FastAPI
 from fastapi.responses import Response
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from prometheus_client import CONTENT_TYPE_LATEST
 
 from app.agent import KnowledgeAgent
@@ -29,12 +29,39 @@ class AskRequest(BaseModel):
     该字段仅用于演示，生产准确率应来自抽样人工标注或独立 Judge。
     """
 
-    query: str = Field(min_length=1, description="User question sent to the Knowledge Agent.")
-    task_id: str | None = Field(default=None, description="Optional caller-provided task identifier.")
+    query: str = Field(
+        min_length=1,
+        max_length=4096,
+        description="User question sent to the Knowledge Agent.",
+    )
+    task_id: str | None = Field(
+        default=None,
+        max_length=128,
+        description="Optional caller-provided task identifier.",
+    )
     expected_answer_contains: str | None = Field(
         default=None,
+        max_length=1024,
         description="Optional key fact used to increment answer-correct metrics in demos.",
     )
+
+    @field_validator("query")
+    @classmethod
+    def normalize_query(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("query 不能是空白字符串")
+        return normalized
+
+    @field_validator("expected_answer_contains")
+    @classmethod
+    def normalize_expected_answer(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("expected_answer_contains 不能是空白字符串")
+        return normalized
 
 
 @app.get("/health")

--- a/code/P5/app/schemas.py
+++ b/code/P5/app/schemas.py
@@ -94,19 +94,25 @@ class EvalCase:
     @classmethod
     def from_mapping(cls, raw: dict[str, Any]) -> "EvalCase":
         """从 JSONL 单行构造评测样本；这里集中做字段读取，便于定位坏数据。"""
+        def strict_bool(field_name: str, default: bool | None = None) -> bool:
+            value = raw.get(field_name, default)
+            if type(value) is not bool:
+                raise TypeError(f"{field_name} 必须是 bool 布尔值")
+            return value
+
         return cls(
             task_id=str(raw["task_id"]),
             query=str(raw["query"]),
             category=str(raw["category"]),
             expected_answer_contains=str(raw["expected_answer_contains"]),
-            expected_retrieval_hit=bool(raw["expected_retrieval_hit"]),
-            expected_retrieval_failed=bool(raw.get("expected_retrieval_failed", False)),
-            expected_knowledge_available=bool(raw["expected_knowledge_available"]),
-            expected_tool_called=bool(raw["expected_tool_called"]),
-            expected_tool_success=bool(raw["expected_tool_success"]),
-            expected_handoff=bool(raw["expected_handoff"]),
-            expected_task_success=bool(raw["expected_task_success"]),
-            expected_hallucinated=bool(raw["expected_hallucinated"]),
+            expected_retrieval_hit=strict_bool("expected_retrieval_hit"),
+            expected_retrieval_failed=strict_bool("expected_retrieval_failed", False),
+            expected_knowledge_available=strict_bool("expected_knowledge_available"),
+            expected_tool_called=strict_bool("expected_tool_called"),
+            expected_tool_success=strict_bool("expected_tool_success"),
+            expected_handoff=strict_bool("expected_handoff"),
+            expected_task_success=strict_bool("expected_task_success"),
+            expected_hallucinated=strict_bool("expected_hallucinated"),
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/code/P5/docker-compose.yml
+++ b/code/P5/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       LANGSMITH_TRACING: "false"
       LANGSMITH_PROJECT: easy-data-x-ai-p5
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=2).read()"]
       interval: 10s
@@ -26,7 +26,7 @@ services:
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
     ports:
-      - "9090:9090"
+      - "127.0.0.1:9090:9090"
 
   grafana:
     image: grafana/grafana:11.4.0
@@ -34,12 +34,12 @@ services:
       - prometheus
     environment:
       GF_AUTH_ANONYMOUS_ENABLED: "true"
-      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
-      GF_SECURITY_ADMIN_USER: admin
-      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?必须设置 GRAFANA_ADMIN_PASSWORD}
     volumes:
       - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
       - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
       - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"

--- a/code/P5/tests/test_dashboard_config.py
+++ b/code/P5/tests/test_dashboard_config.py
@@ -16,10 +16,24 @@ class DashboardConfigTest(unittest.TestCase):
         services = compose["services"]
 
         self.assertEqual(set(services), {"agent", "prometheus", "grafana"})
-        self.assertEqual(services["agent"]["ports"], ["8000:8000"])
-        self.assertEqual(services["prometheus"]["ports"], ["9090:9090"])
-        self.assertEqual(services["grafana"]["ports"], ["3000:3000"])
+        self.assertEqual(services["agent"]["ports"], ["127.0.0.1:8000:8000"])
+        self.assertEqual(services["prometheus"]["ports"], ["127.0.0.1:9090:9090"])
+        self.assertEqual(services["grafana"]["ports"], ["127.0.0.1:3000:3000"])
         self.assertEqual(services["agent"]["environment"]["ENVIRONMENT"], "docker")
+        self.assertEqual(services["grafana"]["environment"]["GF_AUTH_ANONYMOUS_ORG_ROLE"], "Viewer")
+        self.assertEqual(
+            services["grafana"]["environment"]["GF_SECURITY_ADMIN_USER"],
+            "${GRAFANA_ADMIN_USER:-admin}",
+        )
+        self.assertTrue(
+            services["grafana"]["environment"]["GF_SECURITY_ADMIN_PASSWORD"].startswith(
+                "${GRAFANA_ADMIN_PASSWORD:?"
+            )
+        )
+        self.assertNotEqual(
+            services["grafana"]["environment"]["GF_SECURITY_ADMIN_PASSWORD"],
+            "admin",
+        )
 
     def test_prometheus_scrapes_agent_metrics_endpoint(self) -> None:
         config = yaml.safe_load((ROOT / "prometheus" / "prometheus.yml").read_text(encoding="utf-8"))

--- a/code/P5/tests/test_evaluators.py
+++ b/code/P5/tests/test_evaluators.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from app.agent import KnowledgeAgent
 from app.evaluation.evaluators import evaluate_cases, load_eval_cases
 from app.evaluation.report import write_evaluation_reports
-from app.schemas import AgentResult
+from app.schemas import AgentResult, EvalCase
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -49,6 +49,24 @@ class KnowledgeAgentTest(unittest.TestCase):
 
 
 class EvaluatorTest(unittest.TestCase):
+    def test_eval_case_rejects_non_boolean_expected_fields(self) -> None:
+        raw = {
+            "task_id": "strict-bool",
+            "query": "问题",
+            "category": "general",
+            "expected_answer_contains": "答案",
+            "expected_retrieval_hit": "false",
+            "expected_knowledge_available": True,
+            "expected_tool_called": False,
+            "expected_tool_success": False,
+            "expected_handoff": False,
+            "expected_task_success": True,
+            "expected_hallucinated": False,
+        }
+
+        with self.assertRaisesRegex((TypeError, ValueError), "bool|布尔"):
+            EvalCase.from_mapping(raw)
+
     def test_evaluator_calculates_retrieval_hit_rate(self) -> None:
         report = evaluate_cases(load_eval_cases(DATASET), KnowledgeAgent())
         self.assertEqual(report.metrics["retrieval_hit_rate"], round(23 / 24, 4))

--- a/code/P5/tests/test_metrics.py
+++ b/code/P5/tests/test_metrics.py
@@ -7,7 +7,7 @@ from fastapi.testclient import TestClient
 from prometheus_client import CollectorRegistry
 
 from app.agent import KnowledgeAgent
-from app.main import app
+from app.main import AskRequest, app
 from app.observability.prometheus_metrics import AgentMetrics, validate_label_names
 
 
@@ -97,6 +97,35 @@ class PrometheusMetricsTest(unittest.TestCase):
         response = TestClient(app).get("/health")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"status": "ok"})
+
+    def test_ask_endpoint_rejects_oversized_fields(self) -> None:
+        client = TestClient(app)
+        limits = {
+            "query": 4096,
+            "task_id": 128,
+            "expected_answer_contains": 1024,
+        }
+
+        for field, limit in limits.items():
+            with self.subTest(field=field):
+                payload = {"query": "有效问题"}
+                payload[field] = "x" * (limit + 1)
+                response = client.post("/ask", json=payload)
+                self.assertEqual(response.status_code, 422)
+
+    def test_ask_endpoint_rejects_blank_query_and_expected_answer(self) -> None:
+        client = TestClient(app)
+        for payload in (
+            {"query": "   "},
+            {"query": "有效问题", "expected_answer_contains": " \t "},
+        ):
+            with self.subTest(payload=payload):
+                response = client.post("/ask", json=payload)
+                self.assertEqual(response.status_code, 422)
+
+    def test_ask_request_normalizes_surrounding_query_whitespace(self) -> None:
+        request = AskRequest(query="  退款要在多久内提交？  ")
+        self.assertEqual(request.query, "退款要在多久内提交？")
 
 
 if __name__ == "__main__":

--- a/code/X2/database/init_seekdb.py
+++ b/code/X2/database/init_seekdb.py
@@ -31,12 +31,12 @@ def main():
     )
     args = parser.parse_args()
 
+    ensure_database()
+
     ok, message = check_connection(args.db_path)
     if not ok:
         print(message)
         sys.exit(1)
-
-    ensure_database()
 
     storage = create_storage(args.db_path)
     storage.init(force=args.force)

--- a/code/X2/docker-compose.yml
+++ b/code/X2/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     image: oceanbase/seekdb:latest
     container_name: x2-seekdb
     ports:
-      - "2881:2881"
-      - "2886:2886"
+      - "127.0.0.1:2881:2881"
+      - "127.0.0.1:2886:2886"
     volumes:
       - seekdb-data:/var/lib/oceanbase
     environment:

--- a/code/X2/parsers/markdown_parser.py
+++ b/code/X2/parsers/markdown_parser.py
@@ -7,7 +7,7 @@ Parses SKILL.md files and extracts frontmatter (YAML) and content.
 import re
 import yaml
 from pathlib import Path
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Mapping, Optional
 
 
 class MarkdownParser:
@@ -57,9 +57,15 @@ class MarkdownParser:
         else:
             frontmatter = {}
             body_content = content
-        
+
+        if not isinstance(frontmatter, Mapping):
+            raise ValueError("frontmatter 必须是 YAML 映射")
+
         # Extract basic information
         name = frontmatter.get('name', '')
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("frontmatter.name 必须是非空字符串")
+        name = name.strip()
         description = frontmatter.get('description', '')
         
         category = self._extract_category(name, frontmatter)

--- a/code/X2/parsers/rule_extractor.py
+++ b/code/X2/parsers/rule_extractor.py
@@ -4,6 +4,7 @@ Rule extractor from Markdown content.
 Extracts rules from Markdown content based on section headers and list items.
 """
 
+import hashlib
 import re
 from typing import List, Dict, Any
 from models.rule import Rule
@@ -209,13 +210,14 @@ class RuleExtractor:
         # Remove leading/trailing underscores
         key = key.strip('_')
         
-        # Limit length
-        if len(key) > 100:
-            key = key[:100]
-        
+        digest = hashlib.sha256(rule_text.encode("utf-8")).hexdigest()[:12]
+
         # If key is too short or empty, use a default
         if len(key) < 3:
             key = f"{rule_type}_rule"
+
+        # 所有 key 都带内容摘要，避免中文被过滤或标点归一化后发生碰撞。
+        key = f"{key[:87]}_{digest}"
         
         return key
     

--- a/code/X2/tests/test_x2_safety.py
+++ b/code/X2/tests/test_x2_safety.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import yaml
+
+
+X2_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(X2_ROOT))
+
+from database import init_seekdb
+from parsers.markdown_parser import MarkdownParser
+from parsers.rule_extractor import RuleExtractor
+from tools import migrate
+
+
+class MarkdownParserSafetyTests(unittest.TestCase):
+    def _write_skill(self, content: str) -> Path:
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        path = Path(temp_dir.name) / "SKILL.md"
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    def test_rejects_non_mapping_frontmatter(self) -> None:
+        path = self._write_skill("---\n- invalid\n---\n正文")
+
+        with self.assertRaisesRegex(ValueError, "frontmatter"):
+            MarkdownParser(str(path)).parse()
+
+    def test_rejects_missing_or_non_string_name(self) -> None:
+        for frontmatter in ({}, {"name": 123}):
+            with self.subTest(frontmatter=frontmatter):
+                path = self._write_skill(
+                    f"---\n{yaml.safe_dump(frontmatter, allow_unicode=True)}---\n正文"
+                )
+                with self.assertRaisesRegex(ValueError, "name"):
+                    MarkdownParser(str(path)).parse()
+
+
+class RuleKeySafetyTests(unittest.TestCase):
+    def test_chinese_rules_receive_unique_stable_keys(self) -> None:
+        content = """## Formatting rules
+- 必须使用明确的标题
+- 必须保留原始示例
+"""
+        first = RuleExtractor(content).extract("demo")
+        second = RuleExtractor(content).extract("demo")
+
+        self.assertEqual(len(first), 2)
+        self.assertEqual([rule.rule_key for rule in first], [rule.rule_key for rule in second])
+        self.assertEqual(len({rule.rule_key for rule in first}), 2)
+        self.assertTrue(all(key.startswith("format_rule_") for key in (rule.rule_key for rule in first)))
+
+    def test_mixed_chinese_rules_with_same_ascii_slug_are_unique_and_stable(self) -> None:
+        content = """## Formatting rules
+- API 必须使用认证保护
+- API 必须限制请求频率
+"""
+        first = RuleExtractor(content).extract("demo")
+        second = RuleExtractor(content).extract("demo")
+
+        first_keys = [rule.rule_key for rule in first]
+        self.assertEqual(first_keys, [rule.rule_key for rule in second])
+        self.assertEqual(len(first_keys), 2)
+        self.assertEqual(len(set(first_keys)), 2)
+        self.assertTrue(all(key.startswith("api_") for key in first_keys))
+
+
+class DatabaseInitializationTests(unittest.TestCase):
+    def test_server_database_is_ensured_before_connection_check(self) -> None:
+        calls: list[str] = []
+        storage = Mock()
+        storage.get_migration_summary.return_value = {
+            "skill_count": 0,
+            "rule_count": 0,
+            "example_count": 0,
+        }
+
+        with (
+            patch.object(init_seekdb, "ensure_database", side_effect=lambda: calls.append("ensure")),
+            patch.object(
+                init_seekdb,
+                "check_connection",
+                side_effect=lambda _path: (calls.append("check") or (True, "ok")),
+            ),
+            patch.object(init_seekdb, "create_storage", return_value=storage),
+            patch.object(sys, "argv", ["init_seekdb.py"]),
+        ):
+            init_seekdb.main()
+
+        self.assertEqual(calls, ["ensure", "check"])
+
+    def test_migration_ensures_database_before_connection_check(self) -> None:
+        calls: list[str] = []
+        storage = Mock()
+        storage.is_initialized.return_value = True
+
+        with (
+            patch.object(migrate, "ensure_database", side_effect=lambda: calls.append("ensure")),
+            patch.object(
+                migrate,
+                "check_connection",
+                side_effect=lambda _path: (calls.append("check") or (True, "ok")),
+            ),
+            patch.object(migrate, "create_storage", return_value=storage),
+        ):
+            migrate.ensure_storage("server-db")
+
+        self.assertEqual(calls, ["ensure", "check"])
+
+
+class DockerComposeSafetyTests(unittest.TestCase):
+    def test_seekdb_ports_bind_to_loopback(self) -> None:
+        compose = yaml.safe_load((X2_ROOT / "docker-compose.yml").read_text(encoding="utf-8"))
+        self.assertEqual(
+            compose["services"]["seekdb"]["ports"],
+            ["127.0.0.1:2881:2881", "127.0.0.1:2886:2886"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/X2/tools/migrate.py
+++ b/code/X2/tools/migrate.py
@@ -20,11 +20,11 @@ from database.seekdb_client import check_connection, ensure_database
 
 
 def ensure_storage(db_path: str) -> None:
+    ensure_database()
     ok, message = check_connection(db_path)
     if not ok:
         print(message)
         sys.exit(1)
-    ensure_database()
     storage = create_storage(db_path)
     if not storage.is_initialized():
         print(f"seekdb not initialized: {db_path}")

--- a/code/config.py
+++ b/code/config.py
@@ -55,6 +55,8 @@ class Config:
     def check_api_key(cls, key_name="SILICONFLOW_API_KEY"):
         """检查 API Key 是否已配置"""
         key = getattr(cls, key_name)
+        if isinstance(key, str):
+            key = key.strip()
         template_value = f"your_{key_name.lower()}_here"
         if key in {"YOUR_API_KEY", template_value} or not key:
             print(f"⚠️  警告: {key_name} 未配置！")

--- a/code/requirements-test.txt
+++ b/code/requirements-test.txt
@@ -1,0 +1,6 @@
+-r P5/requirements.txt
+
+python-dotenv>=1.2.2
+openai>=1.0.0
+pyseekdb>=1.2.0.post1
+PyYAML>=5.4.1

--- a/code/run_tests.py
+++ b/code/run_tests.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""显式运行仓库中的各组 Python 测试，并阻止零测试误报成功。"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@dataclass(frozen=True)
+class TestGroup:
+    name: str
+    start_dir: str
+    pattern: str
+    python_path: str
+
+
+TEST_GROUPS = (
+    TestGroup("配置", "code", "test_config.py", "code"),
+    TestGroup("测试运行器", "code", "test_run_tests.py", "code"),
+    TestGroup("D2", "code/D2", "test*.py", "code"),
+    TestGroup("D3", "code/D3", "test*.py", "code"),
+    TestGroup("D4", "code/D4", "test*.py", "code"),
+    TestGroup("X2", "code/X2/tests", "test*.py", "code/X2"),
+    TestGroup("P5", "code/P5/tests", "test*.py", "code/P5"),
+)
+
+
+def extract_test_count(output: str) -> int:
+    """从 unittest 输出提取数量；缺失或为零时直接失败。"""
+    matches = re.findall(r"\bRan\s+(\d+)\s+tests?\b", output)
+    if len(matches) != 1 or int(matches[0]) == 0:
+        raise RuntimeError("测试组没有实际执行任何测试")
+    return int(matches[0])
+
+
+def run_group(group: TestGroup) -> int:
+    env = os.environ.copy()
+    python_path = str(REPO_ROOT / group.python_path)
+    existing_path = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = (
+        os.pathsep.join((python_path, existing_path))
+        if existing_path
+        else python_path
+    )
+    command = [
+        sys.executable,
+        "-m",
+        "unittest",
+        "discover",
+        "-s",
+        group.start_dir,
+        "-p",
+        group.pattern,
+        "-v",
+    ]
+    result = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    output = result.stdout + result.stderr
+    print(f"\n===== {group.name} =====")
+    print(output.rstrip())
+    if result.returncode != 0:
+        raise RuntimeError(f"{group.name} 测试失败")
+    return extract_test_count(output)
+
+
+def main() -> int:
+    total = 0
+    try:
+        for group in TEST_GROUPS:
+            total += run_group(group)
+    except RuntimeError as exc:
+        print(f"\n测试运行失败：{exc}", file=sys.stderr)
+        return 1
+    print(f"\n全部测试通过，共执行 {total} 个测试。")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/test_config.py
+++ b/code/test_config.py
@@ -35,6 +35,21 @@ class ConfigTests(unittest.TestCase):
                 with patch.object(Config, "SILICONFLOW_API_KEY", value), redirect_stdout(io.StringIO()):
                     self.assertFalse(Config.check_api_key("SILICONFLOW_API_KEY"))
 
+    def test_api_key_validation_ignores_surrounding_whitespace(self):
+        invalid_values = (
+            "   ",
+            "  YOUR_API_KEY  ",
+            "  your_siliconflow_api_key_here  ",
+        )
+
+        for value in invalid_values:
+            with self.subTest(value=value):
+                with patch.object(Config, "SILICONFLOW_API_KEY", value), redirect_stdout(io.StringIO()):
+                    self.assertFalse(Config.check_api_key("SILICONFLOW_API_KEY"))
+
+        with patch.object(Config, "SILICONFLOW_API_KEY", "  sk-example  "):
+            self.assertTrue(Config.check_api_key("SILICONFLOW_API_KEY"))
+
 
 class EnvFileDiscoveryTests(unittest.TestCase):
     def test_prefers_code_env_file(self):
@@ -48,7 +63,10 @@ class EnvFileDiscoveryTests(unittest.TestCase):
             root_env.write_text("SILICONFLOW_API_KEY=root\n", encoding="utf-8")
             code_env.write_text("SILICONFLOW_API_KEY=code\n", encoding="utf-8")
 
-            self.assertEqual(_find_env_file(code_dir), code_env)
+            self.assertEqual(
+                _find_env_file(code_dir).resolve(),
+                code_env.resolve(),
+            )
 
     def test_falls_back_to_repo_root_env_file(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -59,7 +77,10 @@ class EnvFileDiscoveryTests(unittest.TestCase):
             root_env = repo_dir / ".env"
             root_env.write_text("SILICONFLOW_API_KEY=root\n", encoding="utf-8")
 
-            self.assertEqual(_find_env_file(code_dir), root_env)
+            self.assertEqual(
+                _find_env_file(code_dir).resolve(),
+                root_env.resolve(),
+            )
 
     def test_stops_at_repo_root(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/code/test_run_tests.py
+++ b/code/test_run_tests.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import unittest
+
+from run_tests import extract_test_count
+
+
+class TestRunnerSafetyTests(unittest.TestCase):
+    def test_extracts_positive_test_count(self) -> None:
+        self.assertEqual(extract_test_count("Ran 12 tests in 0.2s"), 12)
+
+    def test_rejects_zero_or_missing_test_count(self) -> None:
+        for output in ("Ran 0 tests in 0.0s", "unexpected output"):
+            with self.subTest(output=output):
+                with self.assertRaisesRegex(RuntimeError, "测试"):
+                    extract_test_count(output)
+
+    def test_rejects_ambiguous_or_zero_test_summaries(self) -> None:
+        for output in (
+            "Ran 1 test\nRan 0 tests\nOK",
+            "Ran 2 tests\nRan 2 tests\nOK",
+        ):
+            with self.subTest(output=output):
+                with self.assertRaisesRegex(RuntimeError, "测试"):
+                    extract_test_count(output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 变更摘要

- 加固配置与 D2 切块：参数、Embedding、最大块长、混合检索过滤。
- 加固 D3 检索与工具循环：稳定数据库路径、幂等 upsert、多工具多轮及异常输出保护。
- 加固 D4 记忆安全：UUID、权限隔离、防御性副本、显式蒸馏、租户清理和受保护删除。
- 加固 X2/P5：规则 ID、防御性解析、建库顺序、请求边界、端口绑定和 Grafana 配置。
- 新增显式仓库测试入口并接入 CI；任何测试组执行 0 个测试都会失败。
- 已合入最新 `main`，包含已合并的 #72、#73、#74、#75；#75 的 19 项 D1 工具循环测试已纳入统一测试入口。

## 验证结果

- `python3 code/run_tests.py`：128/128 通过。
- `python3 -m compileall -q code`：通过。
- `npm ci`：通过。
- `npm run docs:build`：通过。
- d1_4 Mock 示例离线完整入口：通过。
- d1_5 fake seekdb + fake model 完整入口：通过。
- D2 离线策略示例：3/3 通过。
- D4 纯 Python 示例：4/4 通过。
- X2 SKILL 解析示例：通过，9 条规则 ID 唯一。
- P5 离线评测与 ROI：生成 5 份报告。
- Docker Compose 配置检查：通过，未启动容器。
- GitHub CI 会在 Python 3.11 干净环境重新执行统一的 128 项测试。

## 验证边界

- 未调用真实模型 API，未连接真实 seekdb 服务；相关示例使用假模型和内存假客户端验证完整入口。
- `npm ci` 报告现有依赖树 10 条 advisory（6 low、4 high）；本 PR 未执行可能破坏 VitePress 固定版本的自动升级。
- 保留 `oceanbase/seekdb:latest`，不猜测不存在的镜像版本。