### PR TITLE
fix: align Starlette TestClient with httpx2

### DIFF
--- a/code/P5/requirements.txt
+++ b/code/P5/requirements.txt
@@ -1,6 +1,8 @@
 PyYAML>=5.4.1
 fastapi>=0.110
 httpx>=0.27
+# Starlette 1.2+ 的 TestClient 优先使用 httpx2；保留 httpx 兼容旧版本。
+httpx2>=2.0,<3
 langsmith>=0.10
 prometheus-client>=0.20
 uvicorn>=0.27

--- a/code/P5/tests/test_dependency_compatibility.py
+++ b/code/P5/tests/test_dependency_compatibility.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+
+
+class DependencyCompatibilityTest(unittest.TestCase):
+    def test_fastapi_testclient_imports_without_deprecation_warning(self) -> None:
+        """新版 Starlette 应直接使用 httpx2，而不是回退到弃用的 httpx。"""
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import warnings\n"
+                    "from starlette.exceptions import StarletteDeprecationWarning\n"
+                    "warnings.simplefilter('error', StarletteDeprecationWarning)\n"
+                    "from fastapi.testclient import TestClient\n"
+                ),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 变更

- 保留 `httpx` 以兼容旧版 Starlette。
- 新增 `httpx2>=2.0,<3`，让 Starlette 1.2+ 的 `TestClient` 使用推荐客户端。
- 新增真实子进程回归测试，将 `StarletteDeprecationWarning` 提升为错误，防止再次回退到弃用路径。

## 原因

当前依赖范围会安装新版 Starlette，但未安装 `httpx2`。`TestClient` 因此回退到旧 `httpx` 并产生弃用警告。

## 验证

- RED：未安装 `httpx2` 时，回归测试准确捕获弃用警告并失败。
- GREEN：安装声明依赖后，专项回归测试通过。
- P5：38/38 通过，无目标弃用警告。
- 仓库全量测试：186/186 通过，0 跳过。
- `python -m compileall -q code`：通过。
- `python -m pip check`：通过。
- `npm run docs:build`：通过。