### PR TITLE
test: wait for stable seekdb index results

### DIFF
--- a/code/D3/test_d3_pyseekdb_integration.py
+++ b/code/D3/test_d3_pyseekdb_integration.py
@@ -16,18 +16,30 @@ from pyseekdb.client.embedding_function import register_embedding_function
 D3_DIR = Path(__file__).resolve().parent
 
 
-def wait_for_documents(search, timeout_seconds=10):
-    """Embedded 的向量/全文索引可能异步就绪，轮询到可查询后再断言。"""
+def wait_for_documents(
+    search,
+    timeout_seconds=10,
+    expected_top1_contains=None,
+):
+    """索引可能异步就绪，等待非空且目标 Top-1 真正可用。"""
     deadline = time.monotonic() + timeout_seconds
     last_result = {}
     while time.monotonic() < deadline:
         last_result = search()
         documents = last_result.get("documents", [[]])
-        if documents and documents[0]:
+        has_documents = documents and documents[0]
+        top1_is_ready = (
+            expected_top1_contains is None
+            or (
+                has_documents
+                and expected_top1_contains in documents[0][0]
+            )
+        )
+        if has_documents and top1_is_ready:
             return last_result
         time.sleep(0.1)
     raise AssertionError(
-        f"seekdb 索引在 {timeout_seconds} 秒内未返回文档：{last_result}"
+        f"seekdb 索引在 {timeout_seconds} 秒内未返回预期文档：{last_result}"
     )
 
 
@@ -93,6 +105,24 @@ def create_test_client(temp_dir):
     )
 
 
+class WaitForDocumentsTests(unittest.TestCase):
+    def test_waits_past_transient_top1_until_expected_document_is_ready(self):
+        responses = iter(
+            [
+                {"documents": [["临时返回的其他文档"]]},
+                {"documents": [["错误码 E-4012：数据库连接池耗尽。"]]},
+            ]
+        )
+
+        result = wait_for_documents(
+            lambda: next(responses),
+            timeout_seconds=1,
+            expected_top1_contains="E-4012",
+        )
+
+        self.assertIn("E-4012", result["documents"][0][0])
+
+
 class RealPyseekdbIntegrationTests(unittest.TestCase):
     def test_ingest_query_hybrid_and_upsert_in_temporary_database(self):
         if platform.system() == "Darwin" and not os.getenv("SEEKDB_TEST_HOST"):
@@ -125,7 +155,8 @@ class RealPyseekdbIntegrationTests(unittest.TestCase):
                         lambda: compare["vector_only"](
                             "E-4012",
                             target_collection=collection,
-                        )
+                        ),
+                        expected_top1_contains="E-4012",
                     )
                     self.assertIn("E-4012", vector_results["documents"][0][0])
 
@@ -134,7 +165,8 @@ class RealPyseekdbIntegrationTests(unittest.TestCase):
                             "E-4012 错误怎么解决",
                             "E-4012",
                             target_collection=collection,
-                        )
+                        ),
+                        expected_top1_contains="E-4012",
                     )
                     self.assertIn("E-4012", hybrid_results["documents"][0][0])
 


### PR DESCRIPTION
## 背景

PR #80 合入后的主分支 CI 中，D3 真实 seekdb 集成测试偶发取得错误的 Top-1 文档。

失败记录：https://github.com/datawhalechina/easy-data-x-ai/actions/runs/30439500755

## 原因

seekdb 的向量/全文索引异步就绪。原测试只要查询返回任意非空文档就停止轮询，可能在索引尚未稳定时把临时结果当成最终结果，随后断言失败。

## 修复

- 支持等待预期文档真正成为 Top-1 后再继续断言
- 向量检索和混合检索都等待 `E-4012` 文档就绪
- 增加回归测试，覆盖“先返回错误 Top-1，随后返回预期文档”的竞态

## 验证

- 新回归测试：通过
- 真实 seekdb 集成测试连续 5 次：5/5 通过
- 全仓 Python 测试：206/206 通过，0 失败、0 跳过
- `python -m compileall -q code`：通过
- `python -m pip check`：通过
- `npm run docs:build`：通过
- `git diff --check`：通过
- 敏感信息扫描：未发现 API Key、本机路径或本地模型配置
