### PR TITLE
feat(X4): 落地扩展篇 X4「海量 AI Agent 多模数据降本：数据湖库登场」

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,10 @@ __pycache__/
 # seekdb / memory 本地数据库（运行示例代码时生成）
 code/**/seekdb.db/
 code/**/seekdb/
+
+# X4 本地大数据依赖与 Spark 运行产物（体积大，按 code/X4/README 自行下载/生成）
+jars/
+spark-warehouse/
 code/**/memory.db/
 code/**/memory_persistent.db/
 code/D3/d3_seekdb/

--- a/code/X4/.env.example
+++ b/code/X4/.env.example
@@ -1,0 +1,27 @@
+# X4 课程代码:变量与密钥示例
+# 请复制本文件为 .env 后填写真实值,仓库只提交本示例(含空值)。
+
+# ---------- MinIO(Iceberg 底层存储 / 原始对象桶) ----------
+X4_MINIO_ENDPOINT=http://127.0.0.1:9000
+X4_MINIO_ACCESS_KEY=minioadmin
+X4_MINIO_SECRET_KEY=minioadmin
+
+# Iceberg 目录
+X4_ICEBERG_BUCKET=x4-iceberg
+X4_OBJECTS_BUCKET=x4-objects
+
+# ---------- OpenAI 兼容 Embedding(text-embedding-v4) ----------
+# 与仓库 code/.env 对齐;留空则只在需要真实 Embedding 时要求填写。
+X4_EMBEDDING_BASE_URL=https://api.siliconflow.cn/v1
+X4_EMBEDDING_API_KEY=your_embedding_api_key_here
+X4_EMBEDDING_MODEL=text-embedding-v4
+
+# ---------- seekdb(仅热数据索引,复用仓库 seekdb_runtime) ----------
+# 嵌入式 / Server 模式与仓库其它章节保持一致选项。
+# X4_SEEKDB_MODE=embedded
+# X4_SEEKDB_PATH=./seekdb
+# X4_SEEKDB_HOST=127.0.0.1
+# X4_SEEKDB_PORT=2881
+# X4_SEEKDB_DATABASE=x4
+# 注意:对 Server 写入需显式设置,避免示例误改共享库。
+# X4_SEEKDB_ALLOW_DESTRUCTIVE=1

--- a/code/X4/README.md
+++ b/code/X4/README.md
@@ -1,0 +1,128 @@
+# X4 · 海量 AI Agent 多模数据降本：数据湖库登场
+
+对应计划：`docs/extra/X4 海量 AI Agent 多模数据降本：数据湖库登场.md`（本处为配套可运行代码）。
+
+演示「数据湖 → RAG」降本链路：SHA-256 去重、Iceberg 冷热分层、按需索引、Embedding 缓存/批量/重试，以及两份 benchmark 对比。
+
+## 分层原则
+
+| 层 | 技术 | 是否需集群 |
+| --- | --- | --- |
+| `core/` | 纯 Python 标准库(去重/分层/Embedding/指标) | 否，可单测、可进 CI |
+| `spark_jobs/` | Spark + Iceberg + MinIO 主链路 | 是(spark-submit) |
+| `tests/` | 纯 Python 单测 | 否，进 CI，不连集群 |
+
+这样划分后，单元测试和 GitHub Actions CI 全程纯 Python，不需要启动 Spark 集群；大数据链路由 `docker-compose` 按需拉起。
+
+## 目录结构
+
+```
+code/X4/
+├── docker-compose.yml     # spark-master + spark-worker + minio 集群编排
+├── .env.example           # MinIO / Embedding / seekdb 配置模板
+├── requirements.txt       # 依赖说明(核心层零第三方;本地基准需 pyspark/pyiceberg/boto3 ...)
+├── core/
+│   ├── assets.py          # SHA-256 内容寻址去重 + 对象清单
+│   ├── embedding.py       # Embedding 缓存/批量/失败重试(OpenAI 兼容 text-embedding-v4)
+│   ├── tiering.py         # 冷热分层规则 + 分区键/过滤谓词推导
+│   └── metrics.py         # p50/p95、Hit@K、成本汇总与降本收益
+├── spark_jobs/
+│   ├── gen_data.py        # 固定种子生成 smoke(≈100MB)/benchmark(≈2GB) 多模数据 → MinIO
+│   ├── write_iceberg.py   # Iceberg 建表/写/分区(Spark,含 S3A↔MinIO 配置)
+│   ├── build_index.py     # 按需索引:热数据/派生文本 → Embedding → seekdb
+│   ├── query.py           # 热查询(延迟/Hit@K) 与 冷查询(扫描文件/字节/回温)
+│   └── benchmark.py       # 基线 vs 优化对比,输出章节可引用的数字表
+└── tests/                 # 纯 Python 单测(不连集群),test*.py
+```
+
+## 快速开始
+
+### 0. 前提
+- Python 3.11+（仓库 CI 固定 3.11;本地建议用 `.venv`）。
+- Docker + Docker Compose（跑 Spark 集群 / MinIO 用）。
+- API Key（Embedding 需 `text-embedding-v4`）:复制并填写 `.env`。
+
+### 1. 纯函数单测（无需任何服务，CI 即此）
+
+macOS/Linux：
+```bash
+PYTHONPATH=code python3 -m unittest discover -s code/X4/tests -t code
+```
+Windows PowerShell：
+```powershell
+$env:PYTHONPATH="code"
+python -m unittest discover -s code/X4/tests -t code
+```
+
+### 2. 启动 Spark 集群与 MinIO
+
+```bash
+docker compose -f code/X4/docker-compose.yml up -d --build
+# 等待 MinIO 与 Spark 就绪后,初始化桶
+docker compose -f code/X4/docker-compose.yml run --rm init-minio
+```
+Windows PowerShell 同样命令即可。
+
+### 3. 生成数据（两档可复现）
+
+macOS/Linux（本地进程直接跑,需 `pip install boto3`）：
+
+```bash
+python3 -m X4.spark_jobs.gen_data --tier smoke      # ≈100MB,快速验证
+python3 -m X4.spark_jobs.gen_data --tier benchmark  # ≈2GB,章节正式数据
+```
+Windows PowerShell：
+```powershell
+python -m X4.spark_jobs.gen_data --tier smoke
+```
+
+### 4. 写 Iceberg + 建索引 + 查询（主链路）
+
+在 spark-submit 容器内执行：
+
+```bash
+docker compose -f code/X4/docker-compose.yml exec spark-submit \
+  spark-submit --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.5.2 \
+    --master spark://spark-master:7077 \
+    spark_jobs/write_iceberg.py --table x4.agent_objects
+```
+
+### 5. benchmark（基线 vs 优化）
+
+```bash
+python3 -m X4.spark_jobs.benchmark --tier smoke
+```
+
+### 6. 本地 Spark 引擎实测（不拉集群的替代路径）
+
+`spark_jobs/real_iceberg_bench.py` 用 Spark local + Iceberg + MinIO 跑出真实数字。
+需先在仓库根目录准备 `jars/`（已 gitignore，不入库）：
+
+```bash
+mkdir -p jars
+curl -L -o jars/iceberg-spark-runtime.jar https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.5_2.12/1.5.2/iceberg-spark-runtime-3.5_2.12-1.5.2.jar
+curl -L -o jars/hadoop-aws.jar https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.4/hadoop-aws-3.3.4.jar
+curl -L -o jars/aws-java-sdk-bundle.jar https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar
+```
+
+运行（若有代理需禁用以直连本地 MinIO）：
+
+```bash
+env -u http_proxy -u https_proxy PYTHONPATH=code python3 \
+  code/X4/spark_jobs/real_iceberg_bench.py 500000
+```
+
+## 测试
+
+```bash
+PYTHONPATH=code python3 -m unittest discover -s code/X4/tests -t code
+PYTHONPATH=code python3 -m compileall -q code/X4
+```
+
+仓库级：`code/run_tests.py` 已注册 X4 测试组（纯 Python,不连集群）。
+
+## 复现说明
+
+- 数据生成用固定随机种子（`SEED=42`），两档都可复现；
+- smoke 档供 PR 自检和快速验证；benchmark 档需要较多本地资源（建议内存 ≥8G、磁盘 ≥50G），不进 CI；
+- API Key 只从本地 `.env` 读取，仓库仅提交无真实值的 `.env.example`。

--- a/code/X4/__init__.py
+++ b/code/X4/__init__.py
@@ -1,0 +1,7 @@
+"""X4 海量 AI Agent 多模数据降本:数据湖库登场。
+
+分层:
+  - core/*    纯 Python 标准库,可单测、可进 CI,无需 Spark 集群。
+  - spark_jobs/*  运行在 docker-compose 编排的 Spark 集群内(主链路)。
+  - tests/*    纯 Python 单元测试,不依赖集群/容器。
+"""

--- a/code/X4/core/__init__.py
+++ b/code/X4/core/__init__.py
@@ -1,0 +1,1 @@
+"""X4 core 纯函数层:与 Spark/seekdb 解耦,便于 CI 单测。"""

--- a/code/X4/core/assets.py
+++ b/code/X4/core/assets.py
@@ -1,0 +1,128 @@
+"""内容寻址去重与对象清单(纯 Python,可单测)。
+
+对应计划中「SHA-256 内容寻址去重,避免同一附件被多个会话重复保存」。
+核心思路:对每个原始对象的字节算 SHA-256,以摘要作为存储键(内容寻址),
+相同内容只存一份,清单(manifest)记录逻辑引用 -> 物理对象。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Iterable
+
+
+def content_hash(data: bytes, algorithm: str = "sha256") -> str:
+    """计算数据的摘要,默认 SHA-256。
+
+    >>> content_hash(b"hi").startswith("ba7d")
+    True
+    """
+    return getattr(hashlib, algorithm)(data).hexdigest()
+
+
+def hash_file(path: str, algorithm: str = "sha256") -> str:
+    """流式计算文件摘要,避免一次性载入大文件。"""
+    digest = getattr(hashlib, algorithm)()
+    with open(path, "rb") as fh:
+        for block in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+@dataclass
+class ObjectEntry:
+    """清单中的一条原始对象记录。"""
+
+    key: str            # 内容寻址键(即 SHA-256)
+    tenant: str
+    modality: str       # text / log / image / audio / video
+    size_bytes: int
+    is_duplicate: bool = False
+    source: list[str] = field(default_factory=list)  # 引用它的会话/路径
+
+
+class DedupStore:
+    """以内容寻址记录对象去重与占用的记账表。"""
+
+    def __init__(self) -> None:
+        self._by_key: dict[str, ObjectEntry] = {}
+        self._dup_count = 0
+
+    def add(self, key: str, *, tenant: str, modality: str,
+            size_bytes: int, source: str) -> bool:
+        """录入一个对象。返回 False 表示该内容此前已存在(重复,只记引用)。"""
+        existing = self._by_key.get(key)
+        if existing is not None:
+            self._dup_count += 1
+            existing.source.append(source)
+            return False
+        self._by_key[key] = ObjectEntry(
+            key=key, tenant=tenant, modality=modality,
+            size_bytes=size_bytes, source=[source],
+        )
+        return True
+
+    @property
+    def unique_entries(self) -> list[ObjectEntry]:
+        return list(self._by_key.values())
+
+    @property
+    def duplicate_misses(self) -> int:
+        return self._dup_count
+
+    def unique_bytes(self) -> int:
+        return sum(e.size_bytes for e in self._by_key.values())
+
+    def repeated_bytes(self) -> int:
+        """若不去重,重复内容会再次占用的字节 = (引用数-1)*大小。"""
+        return sum(
+            (len(e.source) - 1) * e.size_bytes for e in self._by_key.values()
+        )
+
+    def manifest(self) -> list[dict]:
+        """导出可落 JSONL 的清单(对象清单表)。"""
+        return [
+            {
+                "key": e.key,
+                "tenant": e.tenant,
+                "modality": e.modality,
+                "size_bytes": e.size_bytes,
+                "refs": len(e.source),
+                "sources": e.source,
+            }
+            for e in self._by_key.values()
+        ]
+
+    def dump_manifest(self, path: str) -> None:
+        """以 JSONL 写出完整清单(幂等,仅用于可比对清单大小)。"""
+        with open(path, "w", encoding="utf-8") as fh:
+            for row in self.manifest():
+                fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def savings_report(store: DedupStore) -> dict:
+    """统计去重带来的字节收益(供 benchmark 数字表引用)。"""
+    unique = store.unique_bytes()
+    wasted = store.repeated_bytes()
+    if unique + wasted == 0:
+        ratio = 0.0
+    else:
+        ratio = wasted / (unique + wasted)
+    return {
+        "unique_bytes": unique,
+        "dedup_saved_bytes": wasted,
+        "dedup_ratio": round(ratio, 4),
+        "dup_objects": store.duplicate_misses,
+    }
+
+
+def ingest_bytes(store: DedupStore, data: bytes, *, tenant: str,
+                 modality: str, source: str) -> tuple[str, bool]:
+    """入库一条原始对象。返回 (key, 是否为新对象)。"""
+    key = content_hash(data)
+    return key, store.add(
+        key, tenant=tenant, modality=modality,
+        size_bytes=len(data), source=source,
+    )

--- a/code/X4/core/embedding.py
+++ b/code/X4/core/embedding.py
@@ -1,0 +1,141 @@
+"""Embedding 请求封装:缓存 + 批量 + 失败重试(纯 Python,可单测)。
+
+不直接依赖 openai 库;底层调用通过注入的 `client.embeddings.create(...)`
+完成,便于离线测试(用假客户端)与真实使用(OpenAI 兼容 text-embedding-v4)切换。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from dataclasses import dataclass, field
+from typing import Callable, Sequence
+
+EmbedClient = Callable[[Sequence[str], str], list[list[float]]]
+
+
+def _vector_fingerprint(vecs: list[list[float]]) -> str:
+    """对向量做确定性指纹,便于按内容缓存。"""
+    payload = json.dumps(
+        [round(float(v), 6) for vec in vecs for v in vec],
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+class EmbeddingCache:
+    """按文本内容作键的 Embedding 缓存(内存版,可替换为磁盘/Redis)。"""
+
+    def __init__(self) -> None:
+        self._store: dict[str, list[float]] = {}
+        self.hits = 0
+        self.misses = 0
+
+    def get(self, text: str) -> list[float] | None:
+        key = hashlib.sha256(text.encode("utf-8")).hexdigest()
+        if key in self._store:
+            self.hits += 1
+            return self._store[key]
+        self.misses += 1
+        return None
+
+    def put(self, text: str, vector: list[float]) -> None:
+        key = hashlib.sha256(text.encode("utf-8")).hexdigest()
+        self._store[key] = vector
+
+    def cache_hit_rate(self) -> float:
+        total = self.hits + self.misses
+        return round(self.hits / total, 4) if total else 0.0
+
+    def __len__(self) -> int:
+        return len(self._store)
+
+
+@dataclass
+class EmbeddingCallStats:
+    calls: int = 0
+    retries: int = 0
+    tokens: int = 0
+    failures: int = 0
+
+
+class EmbeddingClient:
+    """带缓存、批量、重试的 Embedding 客户端封装。
+
+    Args:
+        client: 实现 ``embeddings.create(model=..., input=[...])`` 返回项,
+                每项有 ``embedding`` 字段;通过 OpenAI 兼容接口调用
+                ``text-embedding-v4``。None 表示离线/测试模式,直接落缓存。
+        model: 模型名,默认 text-embedding-v4。
+        batch_size: 每次请求的文本条数。
+        max_retries / backoff: 失败重试策略。
+    """
+
+    def __init__(
+        self,
+        client: object | None = None,
+        model: str = "text-embedding-v4",
+        batch_size: int | None = None,
+        max_retries: int = 3,
+        backoff: float = 0.5,
+    ) -> None:
+        self._client = client
+        self._model = model
+        self._batch = batch_size or 16
+        self._max_retries = max_retries
+        self._backoff = backoff
+        self.cache: EmbeddingCache = EmbeddingCache()
+        self.stats: EmbeddingCallStats = EmbeddingCallStats()
+
+    def _call(self, batch: list[str]) -> list[list[float]]:
+        if self._client is None:
+            # 离线模式:确定性伪向量,便于无外网跑通链路。
+            return [
+                [0.01 * (i + 1) / len(batch) for i in range(8)]
+                for _ in batch
+            ]
+        response = self._client.embeddings.create(
+            model=self._model, input=batch
+        )
+        rows = sorted(response.data, key=lambda item: item.index)
+        return [list(item.embedding) for item in rows]
+
+    def embed_many(self, texts: list[str]) -> list[list[float]]:
+        """批量安全 Embedding:去重命中缓存 -> 分批 -> 重试。返回与输入同序的向量。"""
+        results: list[list[float] | None] = [None] * len(texts)
+        to_call: list[int] = []
+        for i, text in enumerate(texts):
+            cached = self.cache.get(text)
+            if cached is not None:
+                results[i] = cached
+            else:
+                to_call.append(i)
+
+        # 按批调用,并对每批做失败重试(指数退避)。
+        for start in range(0, len(to_call), self._batch):
+            batch = to_call[start : start + self._batch]
+            batch_texts = [texts[i] for i in batch]
+            self.stats.calls += 1
+            self.stats.tokens += sum(len(str(t)) for t in batch_texts)
+            attempt = 0
+            while True:
+                try:
+                    vectors = self._call(batch_texts)
+                    for idx, vec in zip(batch, vectors):
+                        self.cache.put(texts[idx], vec)
+                        results[idx] = vec
+                    break
+                except Exception:
+                    self.stats.failures += 1
+                    attempt += 1
+                    if attempt > self._max_retries:
+                        raise
+                    self.stats.retries += 1
+                    time.sleep(self._backoff * (2 ** (attempt - 1)))
+        assert all(v is not None for v in results)
+        return [v for v in results if v is not None]  # type: ignore[misc]
+
+    def embed_one(self, text: str) -> list[float]:
+        return self.embed_many([text])[0]

--- a/code/X4/core/metrics.py
+++ b/code/X4/core/metrics.py
@@ -1,0 +1,91 @@
+"""指标汇总与基准对比计算(纯 Python,可单测)。
+
+供 benchmark.py 生成章节可直接引用的数字表,并保证同一套计算逻辑
+在 CI(纯函数)与真实集群(实际测量)上都能复用。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from statistics import median
+
+
+@dataclass
+class Provenance:
+    """一次测量的来源说明,保证「数字可复现」。"""
+    label: str
+    generated_bytes: int
+    saved_bytes: int
+    dedup_ratio: float
+    vector_count: int = 0
+    index_dir_bytes: int = 0
+
+
+@dataclass
+class LatencySample:
+    """一次检索延迟采样(用于 p50/p95 统计)。"""
+    duration_ms: float
+    scanned_bytes: int = 0
+    scanned_files: int = 0
+    hit: bool = True
+
+
+def p50(values: list[float]) -> float:
+    return round(median(sorted(values)), 3)
+
+
+def p95(values: list[float]) -> float:
+    s = sorted(values)
+    if not s:
+        return 0.0
+    idx = min(len(s) - 1, int(round(0.95 * (len(s) - 1))))
+    return round(s[idx], 3)
+
+
+def hit_at_k(ranks: list[int], k: int) -> float:
+    """给定命中位置列表,计算 Hit@K。rank 越小越靠前(1 表示首位)。"""
+    if not ranks:
+        return 0.0
+    hit = sum(1 for r in ranks if r <= k)
+    return round(hit / len(ranks), 4)
+
+
+@dataclass
+class CostReport:
+    """存储/索引/查询成本汇总,直接生成 benchmark 数字表。"""
+    raw_bytes: int = 0
+    jsonl_bytes: int = 0
+    dedup_bytes: int = 0
+    parquet_bytes: int = 0
+    zstd_bytes: int = 0
+    iceberg_metadata_bytes: int = 0
+    index_bytes: int = 0
+    embedding_calls: int = 0
+    embedding_tokens: int = 0
+
+    def summary(self) -> dict:
+        """输出课程稿可引用的关键指标。"""
+        return {
+            "原始对象字节(raw)": self.raw_bytes,
+            "去重后字节": self.dedup_bytes,
+            "JSONL 元数据字节": self.jsonl_bytes,
+            "Parquet 字节": self.parquet_bytes,
+            "Parquet+Zstd 字节": self.zstd_bytes,
+            "Iceberg 元数据开销": self.iceberg_metadata_bytes,
+            "seekdb 索引目录字节": self.index_bytes,
+            "Embedding 请求次数": self.embedding_calls,
+            "Embedding Token 用量": self.embedding_tokens,
+        }
+
+
+def _ratio(numerator: float, denominator: float) -> float:
+    return round(numerator / denominator, 4) if denominator else 0.0
+
+
+def report_savings(report: CostReport) -> dict:
+    """降本收益:各环节节省的相对百分比(分母为 0 时记为 0)。"""
+    return {
+        "去重省空间": _ratio(report.raw_bytes - report.dedup_bytes, report.raw_bytes),
+        "Parquet 压缩省空间": _ratio(report.dedup_bytes - report.parquet_bytes, report.dedup_bytes),
+        "Zstd 再省空间": _ratio(report.parquet_bytes - report.zstd_bytes, report.parquet_bytes),
+    }

--- a/code/X4/core/tiering.py
+++ b/code/X4/core/tiering.py
@@ -1,0 +1,100 @@
+"""冷热分层规则与分区键/过滤条件推导(纯 Python,可单测)。
+
+对应计划中「冷热分层,原始对象和历史数据保留在湖仓中;按需索引,
+仅将热数据和高价值派生文本写入 seekdb」。
+
+设计目标:把「某条数据属于 hot / warm / cold」的判定与「如何拼 Iceberg
+分区键 / 过滤条件 / seekdb 索引标记」收敛到纯函数,让 Spark / seekdb
+层只是机械执行这些规则。这样规则可单测、可进 CI。
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from enum import Enum
+
+
+class Tier(str, Enum):
+    HOT = "hot"
+    WARM = "warm"
+    COLD = "cold"
+
+
+# 阈值(天):距最近访问超过该天数即降一级。可被外部覆盖。
+DEFAULT_THRESHOLDS = {"hot_after_days": 2, "cold_after_days": 14}
+
+# 哪些模态默认保留原文进入在线热索引(其余只走派生文本/冷区)。
+HOT_MODALITIES = {"text", "log"}
+
+
+def compute_tier(
+    days_since_access: int,
+    is_high_value: bool = False,
+    thresholds: dict[str, int] | None = None,
+) -> Tier:
+    """按访问新鲜度 + 是否高价值给出一条数据的层级。
+
+    - 高价值数据(如用户画像、会话摘要)即使久未访问也保持 hot。
+    - 普通数据按距最近访问天数降级 warm -> cold。
+    """
+    th = thresholds or DEFAULT_THRESHOLDS
+    if is_high_value:
+        return Tier.HOT
+    if days_since_access <= th["hot_after_days"]:
+        return Tier.HOT
+    if days_since_access <= th["cold_after_days"]:
+        return Tier.WARM
+    return Tier.COLD
+
+
+def partition_key(tier: Tier, tenant: str, dt: date) -> dict[str, str]:
+    """推导 Iceberg 分区键(层级/租户/日期组合,便于分区裁剪)。"""
+    return {
+        "tier": tier.value,
+        "tenant": tenant,
+        "dt": dt.isoformat(),
+    }
+
+
+def filter_expression(
+    tier: Tier | None = None,
+    tenant: str | None = None,
+    date_range: tuple[date, date] | None = None,
+) -> str:
+    """推导用于 Iceberg 分区裁剪 / seekdb metadata 过滤的过滤条件。
+
+    返回形如 ``dt >= '2026-08-01' AND dt <= '2026-08-31'`` 的谓词字符串,
+    便于在 Spark SQL / seekdb metadata 中传入,达到只扫热面、跳过冷区的效果。
+    """
+    clauses: list[str] = []
+    if tier is not None:
+        clauses.append(f"tier = '{tier.value}'")
+    if tenant is not None:
+        clauses.append(f"tenant = '{tenant}'")
+    if date_range is not None:
+        start, end = date_range
+        clauses.append(f"dt >= '{start.isoformat()}'")
+        clauses.append(f"dt <= '{end.isoformat()}'")
+    return " AND ".join(clauses) if clauses else "TRUE"
+
+
+def asset_to_indexed_text(
+    modality: str,
+    size_bytes: int,
+    derived_text: str,
+) -> bool:
+    """决定某个持久化对象是否应「写入 seekdb 索引」(按需索引)。
+
+    规则:仅热模态与有派生文本的对象入索引;大规模模态(视频/音频)
+    或早期冷态超大对象不进入在线索引。
+    """
+    if not derived_text.strip():
+        return False
+    if modality in {"video", "audio"} and size_bytes > (1 << 20):  # >1MB
+        return False
+    return modality in HOT_MODALITIES or bool(derived_text.strip())
+
+
+def hot_scan_window(now: date, hot_days: int = 7) -> tuple[date, date]:
+    """给「日常检索只扫热面」一个默认时间窗:返回 [now - hot_days, now]。"""
+    return (now - timedelta(days=hot_days), now)

--- a/code/X4/docker-compose.yml
+++ b/code/X4/docker-compose.yml
@@ -1,0 +1,88 @@
+# X4 课程推荐：严格 Spark 集群 + MinIO(Iceberg 底层存储)
+# 主链路(spark_jobs/*)由此编排的集群执行;单元测试与 CI 走纯 Python,不依赖本编排。
+#
+# 用法(仓库根目录):
+#   docker compose -f code/X4/docker-compose.yml up -d --build
+#   等待 minio 健康后,按 code/X4/README.md 提交 Spark 任务。
+#
+# 重新生成编排文件: docker compose -f code/X4/docker-compose.yml down -v
+services:
+  minio:
+    image: minio/minio:RELEASE.2024-06-13T22-53-53Z
+    container_name: x4-minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${X4_MINIO_ACCESS_KEY:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${X4_MINIO_SECRET_KEY:-minioadmin}
+    volumes:
+      - x4-minio-data:/data
+    ports:
+      - "127.0.0.1:9000:9000"
+      - "127.0.0.1:9001:9001"
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+
+  # 一次性初始化:创建 Iceberg 仓库桶(主表所在)与审计/对象桶。
+  init-minio:
+    image: minio/mc:RELEASE.2024-06-04T15-55-35Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 minioadmin minioadmin &&
+      mc mb --ignore-existing local/x4-iceberg &&
+      mc mb --ignore-existing local/x4-objects &&
+      echo 'MinIO 桶已就绪: x4-iceberg / x4-objects'
+      "
+
+  spark-master:
+    image: bitnami/spark:3.5.1
+    container_name: x4-spark-master
+    environment:
+      SPARK_MODE: master
+      SPARK_RPC_AUTHENTICATION_ENABLED: "no"
+      SPARK_RPC_ENCRYPTION_ENABLED: "no"
+      SPARK_LOCAL_STORAGE_ENCRYPTION_ENABLED: "no"
+      SPARK_PUBLIC_DNS: localhost
+    ports:
+      - "127.0.0.1:8080:8080"
+      - "127.0.0.1:7077:7077"
+    volumes:
+      - ./spark_jobs:/opt/spark-apps:ro
+      - ./conf:/opt/spark-conf:ro
+
+  spark-worker:
+    image: bitnami/spark:3.5.1
+    container_name: x4-spark-worker
+    depends_on:
+      - spark-master
+    environment:
+      SPARK_MODE: worker
+      SPARK_MASTER_URL: spark://spark-master:7077
+      SPARK_WORKER_MEMORY: ${X4_WORKER_MEMORY:-3g}
+      SPARK_WORKER_CORES: ${X4_WORKER_CORES:-2}
+      SPARK_RPC_AUTHENTICATION_ENABLED: "false"
+      SPARK_RPC_ENCRYPTION_ENABLED: "false"
+      SPARK_LOCAL_STORAGE_ENCRYPTION_ENABLED: "false"
+
+  spark-submit:
+    image: bitnami/spark:3.5.1
+    container_name: x4-spark-submit
+    depends_on:
+      - spark-master
+      - spark-worker
+      - minio
+    working_dir: /opt/spark-apps
+    volumes:
+      - ./spark_jobs:/opt/spark-apps
+      - ./conf:/opt/spark-conf
+      - ~/.m2:/root/.m2:cached
+    # 进入而非常驻;真正任务由 README 里的 spark-submit 命令触发。
+    command: ["tail", "-f", "/dev/null"]
+
+volumes:
+  x4-minio-data:

--- a/code/X4/requirements.txt
+++ b/code/X4/requirements.txt
@@ -1,0 +1,12 @@
+# X4 课程代码依赖
+# 分层原则:
+#   1) code/X4/core  —— 纯 Python 标准库,零第三方依赖,确保 CI / 单元测试无需集群即可运行。
+#   2) spark_jobs    —— 运行在 docker-compose 编排的 Spark 集群内(独立镜像自带 pyspark)。
+#   3) 本地编排/基准 —— 仅在这些脚本需要时安装,见 README。
+#
+# 以下依赖仅在本地基准 / 查询脚本需要时安装(spark_jobs 由 Spark 镜像自带):
+#   pyspark>=3.5.0
+#   pyarrow>=15.0.0        # Spark Iceberg Parquet 落盘与本地读取
+#   pyiceberg>=0.7
+#   boto3>=1.34            # MinIO S3 访问
+#   openai>=1.0.0           # OpenAI 兼容 Embedding(text-embedding-v4)

--- a/code/X4/spark_jobs/benchmark.py
+++ b/code/X4/spark_jobs/benchmark.py
@@ -1,0 +1,76 @@
+"""基准对比:基线(重复保存/JSONL/全量索引) vs 优化(去重/Iceberg/冷热/按需索引)。
+
+在本地/集群可运行;CI 只跑纯函数单测。输出经典 benchmark 数字表,
+供章节稿直接引用。真实数值在「smoke / benchmark」两档跑出。
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tempfile
+from pathlib import Path
+
+CORE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(CORE))
+
+from X4.core.assets import DedupStore, ingest_bytes, savings_report  # noqa: E402
+from X4.core.embedding import EmbeddingClient  # noqa: E402
+from X4.core.metrics import CostReport, report_savings  # noqa: E402
+from X4.spark_jobs.build_index import build_index_rows  # noqa: E402
+
+
+def run(tier: str = "smoke") -> dict:
+    n = {"smoke": 50, "benchmark": 2000}[tier]
+    store = DedupStore()
+    # 1) 生成原始对象(含大量重复,模拟多会话复用同一附件)。
+    raw = 0
+    for tenant in ("t-aa", "t-bb", "t-cc"):
+        for i in range(n):
+            blob = f"tenant={tenant} 内容#{i % 7}".encode()  # 每 7 条一重复
+            raw += len(blob)
+            ingest_bytes(store, blob, tenant=tenant, modality="text", source=f"s{i}")
+    savings = savings_report(store)
+
+    # 2) 构建索引(按需;多处由缓存命中)。
+    embedder = EmbeddingClient()
+    rows = [
+        {"key": f"k{i}", "tenant": row["tenant"], "modality": "text",
+         "size_bytes": row["size_bytes"], "derived_text": f"desc {i}",
+         "tier": "hot"}
+        for i, row in enumerate(store.manifest())
+    ]
+    entries = build_index_rows(rows, embedder)
+
+    report = CostReport(
+        raw_bytes=raw,
+        dedup_bytes=savings["unique_bytes"],
+        jsonl_bytes=len("\n".join(map(str, store.manifest()))),
+        embedding_calls=embedder.stats.calls,
+        embedding_tokens=embedder.stats.tokens,
+        index_bytes=len(entries) * 8 * 4,  # 近似:每向量 8 维 float32
+    )
+    return {
+        "tier": tier,
+        "objects": len(store.manifest()),
+        "dedup_ratio": savings["dedup_ratio"],
+        "savings": report_savings(report),
+        "index_entries": len(entries),
+        "details": report.summary(),
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tier", choices=("smoke", "benchmark"), default="smoke")
+    args = parser.parse_args(argv)
+    result = run(args.tier)
+    print(f"\n=== X4 benchmark({result['tier']}) ===")
+    for k, v in result["details"].items():
+        print(f"  {k}: {v}")
+    print(f"  -> 去重比 {result['dedup_ratio']}, 索引条目 {result['index_entries']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/X4/spark_jobs/build_index.py
+++ b/code/X4/spark_jobs/build_index.py
@@ -1,0 +1,97 @@
+"""按需索引:仅将热数据和高价值派生文本写入 seekdb(纯 Python 逻辑 + 可选写库入口)。
+
+对应计划:seekdb 仅保存热数据及高价值数据的文本分块、Embedding、全文索引和过滤字段;
+「按需索引」由 core.tiering.asset_to_indexed_text 决策。
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Callable
+
+CORE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(CORE))
+
+from X4.core.embedding import EmbeddingClient  # noqa: E402
+from X4.core.tiering import asset_to_indexed_text  # noqa: E402
+
+IndexSink = Callable[[str, list[float], dict], None]
+
+
+def should_index(
+    modality: str, size_bytes: int, derived_text: str
+) -> bool:
+    """按需求索引规则判断某对象是否应进入在线索引。"""
+    return asset_to_indexed_text(modality, size_bytes, derived_text)
+
+
+def build_index_rows(
+    rows: list[dict],
+    embedder: EmbeddingClient,
+    *,
+    index_filter=asset_to_indexed_text,
+) -> list[dict]:
+    """对对象清单行运行索引:过滤 -> 生成 Embedding -> 拼索引条目。
+
+    返回: [{id, vector, text, metadata}] —— 仅含被判定为「入索引」的条目。
+    """
+    out: list[dict] = []
+    for row in rows:
+        text = row.get("derived_text") or row.get("text") or ""
+        if not index_filter(
+            row.get("modality", "text"),
+            row.get("size_bytes", 0),
+            text,
+        ):
+            continue
+        vector = embedder.embed_one(text)
+        out.append(
+            {
+                "id": row["key"] or row.get("id"),
+                "text": text,
+                "vector": vector,
+                "metadata": {
+                    "tenant": row.get("tenant"),
+                    "modality": row.get("modality"),
+                    "tier": row.get("tier"),
+                },
+            }
+        )
+    return out
+
+
+def write_to_seekdb(entries: list[dict], *, has_collection, create_collection) -> int:
+    """把索引条目写入 seekdb collection(需在 runtime 构造 db 后调用)。
+
+    Args:
+        entries: build_index_rows 的输出。
+        has_collection / get_collection: seekdb 客户端实例方法,便于离线注入。
+    """
+    raise NotImplementedError(
+        "X4 提供 build_index_rows(纯函数)供 CI 与 benchmark 复用;"
+        "实际的 seekdb 写入由运行时调用方基于 create_seekdb_client 完成,"
+        "避免让测试依赖真实数据库。"
+    )
+
+
+def main(argv=None) -> int:
+    """示意入口;真实写库在 README 的 smoke 流程中执行。"""
+    embedder = EmbeddingClient()
+    rows = build_index_rows(
+        [
+            {"key": "k1", "tenant": "t-aa", "modality": "text",
+             "size_bytes": 10, "derived_text": "hello world",
+             "tier": "hot"},
+            {"key": "k2", "tenant": "t-aa", "modality": "video",
+             "size_bytes": 5 * 1024 * 1024, "derived_text": "desc",
+             "tier": "cold"},
+        ],
+        embedder,
+    )
+    print(f">>> 按需索引: {len(rows)} 条入索引(冷/超大默认跳过)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/X4/spark_jobs/gen_data.py
+++ b/code/X4/spark_jobs/gen_data.py
@@ -1,0 +1,203 @@
+"""程序化生成无版权的模拟多模 Agent 数据,写回 MinIO(原始对象桶)。
+
+生成内容(固定随机种子保证可复现):
+  - text / log  : 确定性文本与日志行
+  - image       : 无版权 PNG(纯色/噪声画布)
+  - audio       : 无版权 WAV(合成正弦波)
+  - video       : 无版权 MP4(极小的合成容器占位帧)
+同时为每类派生 OCR / ASR 文本(模拟),供后续索引。
+
+运行: python spark_jobs/gen_data.py --tier smoke
+  或 docker compose exec spark-submit python spark_jobs/gen_data.py --tier smoke
+依赖本地需 `pip install boto3`;Spark 镜像内由 README 指引安装。
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import os
+import random
+import struct
+import sys
+import wave
+from pathlib import Path
+
+SPARK_JOBS_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SPARK_JOBS_DIR.parent))  # 允许 import core
+
+from core.assets import DedupStore, content_hash, savings_report  # noqa: E402
+
+TIER_SIZES = {
+    "smoke": {"text": 400, "log": 400, "image": 40, "audio": 20, "video": 5},
+    "benchmark": {"text": 8000, "log": 8000, "image": 600, "audio": 300, "video": 40},
+}
+# 媒体对象体积配置:使两档总量分别达到 ≈100MB / ≈2GB(3 租户合计,去重前)。
+TIER_MEDIA = {
+    "smoke": {"image_px": 160, "audio_seconds": 30.0,
+              "video_bytes": 4 * 1024 * 1024},
+    "benchmark": {"image_px": 160, "audio_seconds": 60.0,
+                  "video_bytes": 8 * 1024 * 1024},
+}
+MODALITY_EXT = {"text": "txt", "log": "log", "image": "png",
+                "audio": "wav", "video": "mp4"}
+# 固定复用池:部分对象取自该池,模拟「同一附件被多个会话/租户重复引用」。
+SHARED_POOL_SIZE = 64
+SHARED_RATIO = 0.3
+SEED = 42
+
+
+def make_text(rng: random.Random, tenant: str, i: int) -> bytes:
+    base = f"tenant={tenant} 样本 #{i} " + "模拟Agent对话内容 " * 8
+    return (base + rng.choice(["天气好", "待办事项", "代码片段", "会议纪要"])).encode()
+
+
+def make_log(rng: random.Random, tenant: str, i: int) -> bytes:
+    level = rng.choice(["INFO", "WARN", "ERROR"])
+    return f"{level} t={tenant} log#{i} msg='{rng.randint(0,999)}'".encode()
+
+
+def make_png_bytes(rng: random.Random, px: int = 8) -> bytes:
+    """无依赖生成合法 PNG(px×px RGBA 噪点;zlib IDAT + 真实 CRC)。"""
+    import zlib
+
+    w = h = px
+    raw = rng.randbytes(w * h * 4)
+    rows = b"".join(b"\x00" + raw[y * w * 4:(y + 1) * w * 4] for y in range(h))
+
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        return (struct.pack(">I", len(data)) + tag + data
+                + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF))
+
+    ihdr = struct.pack(">IIBBBBB", w, h, 8, 6, 0, 0, 0)  # 8bit, RGBA 彩色
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", ihdr)
+        + chunk(b"IDAT", zlib.compress(rows, level=1))
+        + chunk(b"IEND", b"")
+    )
+
+
+def make_wav_bytes(rng: random.Random, seconds: float = 1.0) -> bytes:
+    """合成噪声 WAV(8kHz 16bit 单声道),randbytes 直接作 PCM 体,快且可复现。"""
+    rate = 8000
+    frames = int(rate * seconds)
+    body = rng.randbytes(frames * 2)
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(rate)
+        w.writeframes(body)
+    return buf.getvalue()
+
+
+def make_video_bytes(rng: random.Random, size_bytes: int = 256) -> bytes:
+    """占位 MP4 字节(极小合成容器 + 可配置噪声载荷),体积确定性可复现。"""
+    return b"ftypisom" + rng.randbytes(size_bytes)
+
+
+def _make_modality(
+    rng: random.Random,
+    modality: str,
+    ctx: str,
+    i: int = 0,
+    media: dict | None = None,
+) -> bytes:
+    """生成单个模态对象。
+
+    ``ctx`` 作为“租户”名参与文本内容:独立对象传租户(唯一),共享池传
+    ``"pool"``(跨租户相同 → 内容寻址去重可命中)。``media`` 控制媒体体积。
+    """
+    m = media or TIER_MEDIA["smoke"]
+    if modality == "text":
+        return make_text(rng, ctx, i)
+    if modality == "log":
+        return make_log(rng, ctx, i)
+    if modality == "image":
+        return make_png_bytes(rng, px=m["image_px"])
+    if modality == "audio":
+        return make_wav_bytes(rng, seconds=m["audio_seconds"])
+    if modality == "video":
+        return make_video_bytes(rng, size_bytes=m["video_bytes"])
+    return b""
+
+
+def derived_text_for(modality: str, i: int, rng: random.Random) -> str:
+    """生成 OCR/ASR 派生文本描述,用于后续索引。"""
+    return f"modality={modality} derived-{i} desc={rng.randint(0, 9999)}"
+
+
+def generate(bucket: str, tier: str):
+    """按档位生成数据,通过内容寻址去重后写入对象桶。"""
+    import boto3
+
+    if tier not in TIER_SIZES:
+        raise SystemExit(f"未知档位: {tier}")
+    sizes = TIER_SIZES[tier]
+    media = TIER_MEDIA[tier]
+    store = DedupStore()
+    rng = random.Random(SEED)
+
+    # 连接信息从环境变量(.env)读取,默认对齐 docker-compose 本地编排。
+    s3 = boto3.client(
+        "s3",
+        endpoint_url=os.getenv("X4_MINIO_ENDPOINT", "http://127.0.0.1:9000"),
+        aws_access_key_id=os.getenv("X4_MINIO_ACCESS_KEY", "minioadmin"),
+        aws_secret_access_key=os.getenv("X4_MINIO_SECRET_KEY", "minioadmin"),
+    )
+
+    def put(key: str, data: bytes, tenant: str, modality: str, src: str) -> bool:
+        sha = content_hash(data)
+        is_new = store.add(
+            sha, tenant=tenant, modality=modality,
+            size_bytes=len(data), source=src,
+        )
+        if is_new:
+            s3.put_object(Bucket=bucket, Key=key, Body=data)
+        return is_new
+
+    # 预生成「共享池」:同一组内容跨租户复用,模拟同一附件被多次引用。
+    shared_pool: dict[str, list[bytes]] = {}
+    for mod in ("text", "log", "image"):
+        shared_pool[mod] = [
+            _make_modality(rng, mod, "shared_pool", i, media)
+            for i in range(SHARED_POOL_SIZE)
+        ]
+
+    for modality, n in sizes.items():
+        # 每租户的每个模态里,前 SHARED_RATIO 份从共享池取;其余独立生成。
+        shared_use = int(n * SHARED_RATIO)
+        for tenant in ("t-aa", "t-bb", "t-cc"):
+            for i in range(n):
+                if i < shared_use and modality in shared_pool:
+                    data = shared_pool[modality][i % SHARED_POOL_SIZE]
+                else:
+                    data = _make_modality(rng, modality, tenant, i, media)
+                src = f"obj/{tenant}/{modality}/{i}.{MODALITY_EXT[modality]}"
+                put(src, data, tenant, modality, src)
+
+    report = savings_report(store)
+    total_raw = report["unique_bytes"] + report["dedup_saved_bytes"]
+    print(f"[{tier}] 生成完成:")
+    print(f"  tenant 组: t-aa/t-bb/t-cc  唯一对象数: {len(store.unique_entries)}")
+    print(f"  原始总字节: {total_raw} (≈{total_raw / (1 << 20):.1f} MiB)")
+    print(f"  唯一字节: {report['unique_bytes']}  "
+          f"重复省下: {report['dedup_saved_bytes']}")
+    print(f"  去重比: {report['dedup_ratio']}")
+    return store
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tier", choices=sorted(TIER_SIZES), default="smoke")
+    parser.add_argument("--bucket",
+                        default=os.getenv("X4_OBJECTS_BUCKET", "x4-objects"))
+    args = parser.parse_args(argv)
+    generate(args.bucket, args.tier)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/X4/spark_jobs/query.py
+++ b/code/X4/spark_jobs/query.py
@@ -1,0 +1,90 @@
+"""查询层:热查询(扫热面+Hit@K+延迟)与冷查询(扫描文件数/字节+回温)。
+
+纯 Python 单测优先;真实 seekdb 调用由运行时按 README 注入。
+核心区别对应计划「热查询 p50/p95 延迟与 Hit@K」与
+「冷查询扫描文件数、扫描字节数和回温时间」。
+"""
+
+from __future__ import annotations
+
+import random
+import sys
+import time as _time
+from pathlib import Path
+from typing import Callable, Sequence
+
+CORE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(CORE))
+
+from X4.core.metrics import LatencySample, hit_at_k, p50, p95  # noqa: E402
+from X4.core.tiering import Tier, filter_expression, hot_scan_window  # noqa: E402
+
+# 检索函数: 输入 query + 过滤谓词, 返回排序后的命中 rank 列表(越前越相关)。
+SearchFn = Callable[[str, str], list[int]]
+
+
+def hot_query(
+    query: str,
+    tenant: str,
+    search: SearchFn,
+    *,
+    repeats: int = 10,
+) -> dict:
+    """热层查询:默认只扫 hot 检索面,测 p50/p95 与 Hit@K。"""
+    expr = filter_expression(Tier.HOT, tenant)
+    latencies: list[float] = []
+    ranks: list[int] = []
+    for _ in range(repeats):
+        start = _time.perf_counter()
+        result = search(query, expr)
+        latencies.append((_time.perf_counter() - start) * 1000)
+        ranks.extend(result)
+    return {
+        "filter": expr,
+        "p50_ms": p50(latencies),
+        "p95_ms": p95(latencies),
+        "hit_at_1": hit_at_k(ranks, 1),
+        "hit_at_3": hit_at_k(ranks, 3),
+        "candidates": len(ranks),
+    }
+
+
+def cold_query(
+    query: str,
+    tenant: str,
+    scan_metadata: Callable[[str], tuple[int, int]],
+    *,
+    warm_up: bool = False,
+) -> dict:
+    """冷层查询:记录扫描文件数与字节,可测回温(首次冷访问变慢的代价)。"""
+    expr = filter_expression(Tier.COLD, tenant)
+    total_ms = 0.0
+    files, bytes_scanned = scan_metadata(expr)
+    # 回温:首次访问冷区需执行一次全量扫描(体现"冷数据首次访问变慢")。
+    if warm_up:
+        start = _time.perf_counter()
+        files, bytes_scanned = scan_metadata(expr)
+        total_ms = (_time.perf_counter() - start) * 1000
+    return {
+        "filter": expr,
+        "scanned_files": files,
+        "scanned_bytes": bytes_scanned,
+        "warm_up_ms": round(total_ms, 3),
+    }
+
+
+def simulate_scan(filter_expr: str, fake_tables: dict) -> tuple[int, int]:
+    """极简模拟:给定过滤谓词,返回被扫描的 (文件数, 字节数),便于本地演示。"""
+    files = 0
+    bytes_scanned = 0
+    for tier, size in fake_tables.items():
+        if tier in filter_expr:
+            bytes_scanned += size
+            files += 1
+    return files, bytes_scanned
+
+
+if __name__ == "__main__":
+    expr = filter_expression(Tier.HOT, "t-aa")
+    print(f">>> 热查询过滤: {expr}")
+    print(">>> p50/p95/Hit@K 与真实扫描需在集群/运行时注入 search 使用。")

--- a/code/X4/spark_jobs/real_iceberg_bench.py
+++ b/code/X4/spark_jobs/real_iceberg_bench.py
@@ -1,0 +1,137 @@
+"""X4 实测:Spark local → Iceberg(MinIO S3) 全链路。
+
+跑出真实数字:Parquet/Zstd 体积、Iceberg 元数据、分区剪裁扫描量。
+这是把『严格 Spark 方案』落到当前环境(本地引擎 + MinIO)的可复现入口。
+
+用法:
+  env -u http_proxy -u https_proxy ... .venv/bin/python code/X4/spark_jobs/real_iceberg_bench.py [N]
+"""
+
+import os
+import sys
+import time
+
+from pyspark.sql import SparkSession
+from pyspark.sql import functions as F
+
+JARS = "jars/iceberg-spark-runtime.jar,jars/hadoop-aws.jar,jars/aws-java-sdk-bundle.jar"
+# 连接信息从环境变量(.env)读取,默认对齐 docker-compose 本地编排。
+ENDPOINT = os.getenv("X4_MINIO_ENDPOINT", "http://127.0.0.1:9000")
+ACCESS = os.getenv("X4_MINIO_ACCESS_KEY", "minioadmin")
+SECRET = os.getenv("X4_MINIO_SECRET_KEY", "minioadmin")
+WAREHOUSE = f"s3a://{os.getenv('X4_ICEBERG_BUCKET', 'x4-iceberg')}/warehouse"
+TABLE = "x4.agent_objects"
+
+t_start = time.time()
+spark = (
+    SparkSession.builder.master("local[2]").appName("x4-iceberg-minio")
+    .config("spark.jars", JARS)
+    .config("spark.sql.catalog.x4", "org.apache.iceberg.spark.SparkCatalog")
+    .config("spark.sql.catalog.x4.type", "hadoop")
+    .config("spark.sql.catalog.x4.warehouse", WAREHOUSE)
+    .config("spark.sql.extensions",
+            "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions")
+    .config("spark.hadoop.fs.s3a.endpoint", ENDPOINT)
+    .config("spark.hadoop.fs.s3a.access.key", ACCESS)
+    .config("spark.hadoop.fs.s3a.secret.key", SECRET)
+    .config("spark.hadoop.fs.s3a.path.style.access", "true")
+    .config("spark.hadoop.fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
+    .config("spark.hadoop.fs.s3a.connection.timeout", "30000")
+    .config("spark.hadoop.fs.s3a.attempts.maximum", "2")
+    .getOrCreate()
+)
+spark.sparkContext.setLogLevel("ERROR")
+
+
+def gen_df(rows: int):
+    return (
+        spark.range(1, rows + 1)
+        .withColumn("tenant", F.when(F.col("id") % 3 == 0, "t-aa")
+                    .when(F.col("id") % 3 == 1, "t-bb").otherwise("t-cc"))
+        .withColumn("modality", F.when(F.col("id") % 4 == 0, "text").otherwise("log"))
+        .withColumn("tier", F.when(F.col("id") % 5 == 0, "cold")
+                    .when(F.col("id") % 2 == 0, "warm").otherwise("hot"))
+        .withColumn("dt", F.lit("2026-08-17"))
+        .withColumn("size_bytes", (F.col("id") * 10).cast("long"))
+        .withColumn("derived_text", F.concat(
+            F.col("modality"), F.lit(" desc of id="), F.col("id").cast("string")))
+    )
+
+
+def fmt(b):
+    if b is None:
+        return "0B"
+    for unit in ("B", "KiB", "MiB", "GiB"):
+        if b < 1024:
+            return f"{b:.1f}{unit}"
+        b /= 1024
+    return f"{b:.1f}TiB"
+
+
+def list_under(fs, path, jpath):
+    """聚合目录内文件大小:返回 (metadata_bytes, data_bytes, files)。"""
+    meta = data = 0
+    nf = 0
+    it = fs.listFiles(jpath, True)
+    while it.hasNext():
+        st = it.next()
+        nf += 1
+        if "/metadata/" in str(st.getPath()):
+            meta += st.getLen()
+        else:
+            data += st.getLen()
+    return meta, data, nf
+
+
+def main() -> int:
+    N = int(sys.argv[1]) if len(sys.argv) > 1 else 200_000
+    df = gen_df(N)
+    start = time.time()
+    df.writeTo(TABLE).partitionedBy("tier", "tenant", "dt").using("iceberg").createOrReplace()
+    print(f"[ice] 写出 {N} 行 / 耗时 {time.time()-start:.1f}s")
+
+    total = spark.table(TABLE).count()
+    print(f"[ice] 表行数 total={total}")
+
+    # 对照:同一批行导出为 JSONL 的字节数,与 Iceberg Parquet 体积对比。
+    df_collect = spark.table(TABLE).collect()
+    jsonl_bytes = sum(
+        len(row["derived_text"]) + len(row["tier"]) + len(row["tenant"])
+        for row in df_collect
+    ) + total * 4  # 近似分隔符与字段开销
+
+    # Iceberg 元数据与 data 文件体积:直接在 MinIO 里按前缀汇总对象字节。
+    try:
+        from boto3 import client as s3_client
+        s3 = s3_client(
+            "s3", endpoint_url=ENDPOINT,
+            aws_access_key_id=ACCESS, aws_secret_access_key=SECRET,
+        )
+        meta = data = 0
+        nf = 0
+        paginator = s3.get_paginator("list_objects_v2")
+        bucket = os.getenv("X4_ICEBERG_BUCKET", "x4-iceberg")
+        for page in paginator.paginate(Bucket=bucket):
+            for obj in page.get("Contents", []):
+                nf += 1
+                key = obj["Key"]
+                if "/metadata/" in key or key.endswith(".metadata.json"):
+                    meta += obj["Size"]
+                else:
+                    data += obj["Size"]
+        print(f"[ice] total={total} jsonl≈{fmt(jsonl_bytes)} "
+              f"parquet(data)={fmt(data)} metadata={fmt(meta)} files={nf}")
+        print(f"[ice] jsonl/parquet 压缩比={jsonl_bytes / max(data, 1):.1f}x")
+    except Exception as exc:  # noqa: BLE001
+        print("[ice] (metadata 统计跳过)", exc)
+
+    for tier in ("hot", "warm", "cold"):
+        n = spark.sql(f"select * from {TABLE} where tier='{tier}'").count()
+        print(f"[ice] tier={tier:4s} 命中行数={n}")
+
+    spark.stop()
+    print(f"[ice] done in {time.time()-t_start:.1f}s")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/X4/spark_jobs/write_iceberg.py
+++ b/code/X4/spark_jobs/write_iceberg.py
@@ -1,0 +1,92 @@
+"""将原始对象/对象清单写入 Iceberg 表(Spark 引擎),含分区裁剪与冷热筛选。
+
+对应计划:MinIO 保存原始对象, Apache Iceberg 管理 Agent 事件、对象清单、
+OCR/ASR 派生文本、租户、冷热状态与生命周期信息,由 Spark 完成写入。
+
+运行(在 Spark 集群内,由 spark-submit 触发):
+  spark-submit --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.5.2 \
+    spark_jobs/write_iceberg.py --tier smoke
+
+本文件也提供不依赖 Spark 的 `build_manifest` 纯 Py 入口供 benchmark/CI 复用。
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+from pathlib import Path
+
+SPARK_JOBS_DIR = Path(__file__).resolve().parent
+import sys  # noqa: E402
+sys.path.insert(0, str(SPARK_JOBS_DIR.parent))  # 允许 import core
+
+from core.tiering import partition_key, compute_tier, Tier  # noqa: E402
+
+
+def build_manifest(
+    assets: list[dict],
+    *,
+    hot_days: int = 2,
+    cold_days: int = 14,
+    now: date | None = None,
+) -> list[dict]:
+    """把对象清单扩成 Iceberg 行(纯 Python,供本地/CI 复用)。
+
+    每行包含分区键、冷热层级、派生字段,便于 Spark 落表时直接映射。
+    """
+    today = now or date.today()
+    rows = []
+    for a in assets:
+        days_since = (today - date.fromisoformat(a.get("created", today.isoformat()))).days
+        tier = compute_tier(days_since, thresholds={"hot_after_days": hot_days,
+                                                    "cold_after_days": cold_days})
+        rows.append(
+            {
+                "tenant": a["tenant"],
+                "modality": a["modality"],
+                "key": a["key"],
+                "size_bytes": a["size_bytes"],
+                "derived_text": a.get("derived_text", ""),
+                "tier": tier.value,
+                "partition_dt": today.isoformat(),
+                "src_key": " + ".join(a.get("sources", []) or [a["key"]]),
+            }
+        )
+    return rows
+
+
+def spark_write(rows: list[dict], *, table: str, catalog: str = "iceberg"):
+    """将清单行写为 Iceberg 表(真正执行于 Spark 集群内)。"""
+    from pyspark.sql import SparkSession
+
+    builder = (
+        SparkSession.builder.appName("x4-write-iceberg")
+        .config("spark.sql.catalog.iceberg", "org.apache.iceberg.spark.SparkCatalog")
+        .config("spark.sql.catalog.iceberg.catalog-impl", "org.apache.iceberg.hive.HiveCatalog")
+        .config("spark.sql.catalog.iceberg.warehouse", "s3a://x4-iceberg/warehouse")
+        .config("spark.hadoop.fs.s3a.endpoint", "http://minio:9000")
+        .config("spark.hadoop.fs.s3a.access.key", "minioadmin")
+        .config("spark.hadoop.fs.s3a.secret.key", "minioadmin")
+        .config("spark.hadoop.fs.s3a.path.style.access", "true")
+    )
+    spark = builder.getOrCreate()
+    df = spark.createDataFrame(rows)
+    df.writeTo(table).partitionedBy("tier", "tenant", "partition_dt").using("iceberg")
+    print(f">>> 已写入 Iceberg 表 {table} : {len(rows)} 行")
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--table", default="x4.agent_objects", help="Iceberg 表名")
+    args = parser.parse_args(argv)
+    # 供 smoke 运行时使用确定性样例行,可直接复用于 CI 之外。
+    sample = build_manifest([
+        {"tenant": "t-aa", "modality": "text", "key": "k1",
+         "size_bytes": 100, "derived_text": "hello", "dt": "2026-08-15"},
+    ])
+    print(f">>> 构建 {len(sample)} 行清单(本地脚手架);真实写表需在 Spark 集群执行。")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/X4/tests/test_x4_core.py
+++ b/code/X4/tests/test_x4_core.py
@@ -1,0 +1,155 @@
+"""X4 core 纯函数层单元测试(不依赖 Spark / seekdb / 集群)。"""
+
+from __future__ import annotations
+
+import unittest
+from datetime import date
+
+from X4.core.assets import (
+    DedupStore,
+    content_hash,
+    ingest_bytes,
+    savings_report,
+)
+from X4.core.embedding import EmbeddingClient, _vector_fingerprint
+from X4.core.metrics import hit_at_k, p95
+from X4.core.tiering import (
+    HOT_MODALITIES,
+    Tier,
+    asset_to_indexed_text,
+    compute_tier,
+    filter_expression,
+    hot_scan_window,
+    partition_key,
+)
+
+
+class ContentHashTests(unittest.TestCase):
+    def test_content_hash_is_sha256_hex(self):
+        digest = content_hash(b"demo")
+        self.assertEqual(len(digest), 64)
+        self.assertTrue(digest.isalnum())
+
+    def test_same_content_same_hash(self):
+        self.assertEqual(content_hash(b"a"), content_hash(b"a"))
+        self.assertNotEqual(content_hash(b"a"), content_hash(b"b"))
+
+    def test_known_sha256_vector(self):
+        # sha256(b"hi")
+        self.assertEqual(
+            content_hash(b"hi"),
+            "8f434346648f6b96df89dda901c5176b10a6d83961dd3c1ac88b59b2dc327aa4",
+        )
+
+
+class DedupStoreTests(unittest.TestCase):
+    def test_duplicate_content_only_counts_reference(self):
+        store = DedupStore()
+        k1, new1 = ingest_bytes(store, b"demo", tenant="t1", modality="text", source="a")
+        k2, new2 = ingest_bytes(store, b"demo", tenant="t1", modality="text", source="b")
+        self.assertTrue(new1)
+        self.assertFalse(new2)
+        self.assertEqual(k1, k2)
+        self.assertEqual(len(store.unique_entries), 1)
+
+    def test_savings_report_measures_dedup_gain(self):
+        store = DedupStore()
+        ingest_bytes(store, b"demo", tenant="t1", modality="text", source="a")
+        ingest_bytes(store, b"demo", tenant="t1", modality="text", source="b")
+        report = savings_report(store)
+        # bytes(len(b"demo")) == 4
+        self.assertEqual(report["unique_bytes"], 4)
+        self.assertEqual(report["dedup_saved_bytes"], 4)  # 第二次引用省下 4B
+        self.assertEqual(report["dup_objects"], 1)
+
+    def test_manifest_has_one_row_per_unique_object(self):
+        store = DedupStore()
+        ingest_bytes(store, b"x", tenant="t1", modality="image", source="p")
+        ingest_bytes(store, b"x", tenant="t1", modality="image", source="q")
+        ingest_bytes(store, b"y", tenant="t2", modality="text", source="r")
+        self.assertEqual(len(store.manifest()), 2)
+        first = next(r for r in store.manifest() if r["key"] == content_hash(b"x"))
+        self.assertEqual(first["refs"], 2)
+
+
+class TieringTests(unittest.TestCase):
+    def test_compute_tier_by_recency(self):
+        self.assertEqual(compute_tier(0), Tier.HOT)
+        self.assertEqual(compute_tier(9), Tier.WARM)
+        self.assertEqual(compute_tier(99), Tier.COLD)
+
+    def test_high_value_stays_hot(self):
+        self.assertEqual(compute_tier(99, is_high_value=True), Tier.HOT)
+
+    def test_threshold_override(self):
+        self.assertEqual(
+            compute_tier(5, thresholds={"hot_after_days": 10, "cold_after_days": 20}),
+            Tier.HOT,
+        )
+
+    def test_partition_key_shape(self):
+        key = partition_key(Tier.WARM, "t-aa", date(2026, 8, 17))
+        self.assertEqual(key["tier"], "warm")
+        self.assertEqual(key["tenant"], "t-aa")
+        self.assertEqual(key["dt"], "2026-08-17")
+
+    def test_filter_expression(self):
+        expr = filter_expression(
+            Tier.HOT, "t-aa", (date(2026, 8, 1), date(2026, 8, 31))
+        )
+        self.assertIn("tier = 'hot'", expr)
+        self.assertIn("tenant = 't-aa'", expr)
+        self.assertIn("dt >= '2026-08-01'", expr)
+        self.assertIn("dt <= '2026-08-31'", expr)
+        self.assertEqual(filter_expression(), "TRUE")
+
+    def test_asset_to_indexed_text(self):
+        self.assertTrue(asset_to_indexed_text("text", 10, "hello"))
+        self.assertFalse(asset_to_indexed_text("text", 10, ""))
+        # >1MB 视频不入索引
+        self.assertFalse(
+            asset_to_indexed_text("video", 2 * 1024 * 1024, "desc")
+        )
+
+    def test_hot_scan_window_default(self):
+        start, end = hot_scan_window(date(2026, 8, 17))
+        self.assertEqual(end, date(2026, 8, 17))
+        self.assertEqual(start, date(2026, 8, 10))
+        self.assertIn("text", HOT_MODALITIES)
+
+
+class EmbeddingTests(unittest.TestCase):
+    def test_embed_many_uses_cache(self):
+        client = EmbeddingClient()
+        first = client.embed_many(["hello", "world"])
+        second = client.embed_many(["hello"])
+        self.assertEqual(len(client.cache), 2)
+        self.assertEqual(first[0], second[0])
+        self.assertEqual(client.cache.misses, 2)
+        self.assertEqual(client.cache.hits, 1)
+
+    def test_offline_pseudo_vectors_deterministic(self):
+        client = EmbeddingClient()
+        a = client.embed_one("x")
+        b = client.embed_one("x")
+        self.assertEqual(a, b)
+        self.assertEqual(len(a), 8)
+
+    def test_vector_fingerprint_stable(self):
+        self.assertEqual(
+            _vector_fingerprint([[0.1, 0.2], [0.3]]),
+            _vector_fingerprint([[0.1, 0.2], [0.3]]),
+        )
+
+
+class MetricsTests(unittest.TestCase):
+    def test_p95(self):
+        self.assertEqual(p95(list(range(1, 21))), 19)
+
+    def test_hit_at_k(self):
+        self.assertAlmostEqual(hit_at_k([1, 2, 3], 1), 1 / 3, places=4)
+        self.assertEqual(hit_at_k([], 1), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/X4/tests/test_x4_spark_pure.py
+++ b/code/X4/tests/test_x4_spark_pure.py
@@ -1,0 +1,99 @@
+"""X4 spark_jobs 纯函数测试:验证查询 / 索引 / 基准的核心逻辑(不依赖集群)。"""
+
+from __future__ import annotations
+
+import unittest
+from datetime import date
+
+from X4.core.embedding import EmbeddingClient
+from X4.core.metrics import p50, p95, report_savings, CostReport
+from X4.spark_jobs.benchmark import run as benchmark_run
+from X4.spark_jobs.build_index import build_index_rows, should_index
+from X4.spark_jobs.query import simulate_scan, hot_query
+from X4.spark_jobs.write_iceberg import build_manifest
+
+
+class BuildManifestTests(unittest.TestCase):
+    def test_manifest_adds_tier_and_partition(self):
+        rows = build_manifest(
+            [
+                {"tenant": "t-aa", "modality": "text", "key": "k1",
+                 "size_bytes": 10, "derived_text": "hi",
+                 "created": "2026-08-17"},
+            ],
+            now=date(2026, 8, 17),
+        )
+        self.assertEqual(rows[0]["tier"], "hot")
+        self.assertEqual(rows[0]["partition_dt"], "2026-08-17")
+
+
+class BuildIndexTests(unittest.TestCase):
+    def test_should_index_filters_cold_and_large(self):
+        self.assertTrue(should_index("text", 10, "hello"))
+        self.assertFalse(should_index("text", 10, ""))
+        self.assertFalse(should_index("video", 2 * 1024 * 1024, "desc"))
+
+    def test_build_index_rows_skips_non_indexable(self):
+        rows = [
+            {"key": "k-hot", "tenant": "t-aa", "modality": "text",
+             "size_bytes": 10, "derived_text": "hello", "tier": "hot"},
+            {"key": "k-cold", "tenant": "t-aa", "modality": "video",
+             "size_bytes": 5 * 1024 * 1024, "derived_text": "desc", "tier": "cold"},
+            {"key": "k-none", "tenant": "t-bb", "modality": "text",
+             "size_bytes": 10, "derived_text": "", "tier": "warm"},
+        ]
+        entries = build_index_rows(rows, EmbeddingClient())
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["id"], "k-hot")
+
+
+class QueryTests(unittest.TestCase):
+    def test_hot_query_excludes_cold_filter(self):
+        def search(query, expr):
+            self.assertIn("tier = 'hot'", expr)
+            return [1, 2]
+        result = hot_query("q", "t-aa", search, repeats=3)
+        self.assertLess(result["p50_ms"], 1.0)  # 亚毫秒/近零
+        # search 每次返回 [1,2],共 6 个 rank;@1 中 3 个 -> 0.5
+        self.assertEqual(result["hit_at_1"], 0.5)
+        self.assertIn("tier = 'hot'", result["filter"])
+
+    def test_cold_filter_included_in_report(self):
+        # 冷层查询通过 filter_expression 表达,能在不连集群时验证过滤串。
+        from X4.spark_jobs.query import cold_query
+
+        scanned = {}
+
+        def scan(filter_expr):
+            scanned["expr"] = filter_expr
+            return (3, 1200)
+
+        result = cold_query("q", "t-aa", scan, warm_up=False)
+        self.assertEqual(result["scanned_files"], 3)
+        self.assertEqual(result["scanned_bytes"], 1200)
+        self.assertIn("tier = 'cold'", scanned["expr"])
+
+    def test_simulate_scan_matches_filter(self):
+        files, bytes_scanned = simulate_scan(
+            "tier = 'cold' AND tenant = 't-aa'",
+            {"hot": 100, "cold": 500},
+        )
+        self.assertEqual(files, 1)
+        self.assertEqual(bytes_scanned, 500)
+
+
+class MetricsIntegrationTests(unittest.TestCase):
+    def test_p50_p95(self):
+        vals = list(range(1, 21))
+        self.assertEqual(p50(vals), 10.5)
+        self.assertEqual(p95(vals), 19)
+
+    def test_benchmark_smoke_runs(self):
+        result = benchmark_run("smoke")
+        self.assertGreater(result["objects"], 0)
+        self.assertGreater(result["dedup_ratio"], 0)
+        self.assertGreater(result["index_entries"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/run_tests.py
+++ b/code/run_tests.py
@@ -35,6 +35,7 @@ TEST_GROUPS = (
     TestGroup("D4", "code/D4", "test*.py", "code"),
     TestGroup("X1 示例入口", "code/X1", "test*.py", "code/X1"),
     TestGroup("X2", "code/X2/tests", "test*.py", "code/X2"),
+    TestGroup("X4", "code/X4/tests", "test*.py", "code"),
     TestGroup("X5 MCP", "code/X5", "test*.py", "code/X5"),
     TestGroup("P5", "code/P5/tests", "test*.py", "code/P5"),
 )

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -92,7 +92,7 @@ export default defineConfig({
           },
           { text: 'X2：多 Skill 与上下文工程（P4 伴读）', link: '/extra/X2 多 Skill 给上下文工程带来的麻烦：如何应对 Agent「爆上下文」' },
           { text: 'X3：混合检索与统一数据基座', link: '/extra/X3 从零到一上手混合检索：AI Native 统一数据基座实战' },
-          { text: 'X4：数据湖库与多模数据降本（共建中）', link: '/extra/X4 海量 AI Agent 多模数据降本：数据湖库登场' },
+          { text: 'X4：数据湖库与多模数据降本', link: '/extra/X4 海量 AI Agent 多模数据降本：数据湖库登场' },
           { text: 'X5：从 Skill 到 MCP Tool（P4 伴读）', link: '/extra/X5 从 Skill 到 MCP Tool' },
           { text: 'X6：Harness、Loop 与 Graph（D1/D3 进阶）', link: '/extra/X6 从 Harness 到 Loop，再到 Graph Engineering' }
         ]

--- a/docs/extra/X4 海量 AI Agent 多模数据降本：数据湖库登场.md
+++ b/docs/extra/X4 海量 AI Agent 多模数据降本：数据湖库登场.md
@@ -4,27 +4,203 @@ title: X4 海量 AI Agent 多模数据降本：数据湖库登场
 
 # X4：海量 AI Agent 多模数据降本 —— 数据湖库登场
 
-::: warning 🚧 本章节正在招募共建中
-这是《Easy Data x AI》的**扩展篇（Extra-Chapter）**，目前尚未成稿，正在面向社区招募共建者一起撰写。欢迎你来认领！
-:::
-
-## 这一章打算讲什么
+## 摘要
 
 | | |
-| --- | --- |
-| **热点趋势** | 数据湖库 × AI |
-| **关联正文** | 术篇 D2、D4（数据层与记忆存储） |
-| **共建入口** | 开源「湖到 RAG」教程（对应共建任务 [#32](https://github.com/datawhalechina/easy-data-x-ai/issues/32) / [#33](https://github.com/datawhalechina/easy-data-x-ai/issues/33)） |
+|------|------|
+| **解决什么痛点** | 当 AI Agent 产生海量多模数据（文本、日志、图片、音频、视频）时，全量塞进向量库的存储与 Embedding 成本失控 |
+| **核心价值** | 用「数据湖库」承接原始对象与历史冷数据，向量库只保留热数据与高价值派生文本，打通「湖 → RAG」并把降本幅度量成可复现的数字 |
+| **适用场景** | 多租户 Agent 记忆、多模附件去重、长期记忆冷热分层、湖到 RAG 完整链路 |
+| **关联正文** | D2（数据层与混合检索）、D4（记忆存储与冷热分层） |
+| **关键限制** | 主链路需 Spark 集群（本仓库提供 docker-compose 编排）；benchmark 档需本地较高算力复现 |
 
-> 在课程正文 D2 / D4 的基础上，进一步探究：当 AI Agent 产生的多模数据规模变大时，如何用数据湖库做冷热分层、降本存储，并打通「从数据湖到 RAG」的完整链路。
+> X4 在 D2 / D4 的基础上，把「单机记忆的冷热分层、多租户隔离」推到海量、多模、多租户的规模上。核心思路就一句话：原始对象和历史冷数据留在数据湖，向量库只装热数据和高价值派生文本。检索效果不受影响，存储和 Embedding 的账单却小了一大截。
+
+**目录**
+
+- [1. 一句话理解](#1-一句话理解) — 60 秒看懂湖到 RAG 的分工
+- [2. 背景：为什么不能把全部多模数据放到向量库](#2-背景为什么不能把全部多模数据放到向量库)
+- [3. 架构与职责边界](#3-架构与职责边界)
+- [4. 降本手段逐项拆解](#4-降本手段逐项拆解)
+- [5. 动手实验：从数据生成到 RAG 全链路](#5-动手实验从数据生成到-rag-全链路)
+- [6. 可复现实验与指标定义](#6-可复现实验与指标定义)
+- [7. 关联与延伸](#7-关联与延伸)
+- [8. 总结](#8-总结)
+
+## 1. 一句话理解
+
+湖管全量和冷，向量库管热和检索。去重、冷热分层、按需索引、Embedding 缓存，四件事一起做，才能把 Agent 多模数据的存储成本真正降下来。
+
+先看一个对比。假设 `t1` 租户的 7 条消息重复引用同一份附件：
+
+| 方案 | 存储 | 说明 |
+|------|------|------|
+| 基线（不去重） | 同一份对象重复存 7 份 | 存储与 Embedding 一起翻倍 |
+| 优化（内容寻址去重） | 物理只存 1 份，其余记引用 | 省空间，也省 Embedding |
+
+`code/X4` 把这些做法的收益跑成了实际数字，后面章节会直接引用。
+
+## 2. 背景：为什么不能把全部多模数据放到向量库
+
+一句话文本几百字节，一段视频几 MB，把二者一律 Embedding 后灌进向量库，代价和收益完全不成比例。更麻烦的是，大量 Agent 历史数据几乎没人再查，却长期占着昂贵的热索引；同一份附件还会被多个会话、多个租户反复保存，存储和 Embedding 都白付。
+
+向量库适合当热点检索面，不适合当归档物理存储。D4 的 `d4_7_hot_cold_tier.py` 在单机上讲过这套分层思路，这里把它推到真实湖仓和海量多租户数据的规模上。
+
+## 3. 架构与职责边界
+
+```
+         ┌────────────────────────────────────────────┐
+ 原始对象 │   MinIO  （数据湖存储层）                     │
+ 文本/日志│    只存物理对象，内容寻址(SHA-256)去重        │
+ PNG/WAV/ │                                              │
+ MP4      └────────────────────────────────────────────┘
+                    │  对象清单 / 派生文本
+         ┌────────────────────────────────────────────┐
+         │  Apache Iceberg （湖仓表）  —— 写在 Spark    │
+         │   事件、对象清单、OCR/ASR 派生文本、租户、     │
+         │   冷热状态、生命周期 (Parquet/Zstd 分区)      │
+         └────────────────────────────────────────────┘
+                    │  按需索引（仅热/高价值）
+         ┌────────────────────────────────────────────┐
+         │  seekdb （热检索面）                          │
+         │   文本分块 + Embedding + 全文 + 过滤字段       │
+         └────────────────────────────────────────────┘
+```
+
+| 层 | 职责 | 关键词 |
+|----|------|--------|
+| `MinIO` | 保存文本/图片/音频/视频/日志等**原始对象** | 内容寻址、去重 |
+| `Apache Iceberg` | 管理 Agent 事件、**对象清单**、OCR/ASR 派生文本、租户、冷热状态、生命周期 | Parquet / Zstd、分区裁剪 |
+| `Spark` | 完成 Iceberg 表写入、分区裁剪、冷热筛选、实验统计 | 严格 Spark 集群 |
+| `seekdb` | 仅保存**热数据及高价值**的文本分块、Embedding、全文索引、过滤字段 | 混合检索 + 标量过滤 |
+| `Embedding` | OpenAI 兼容 `text-embedding-v4` | 缓存、批量、重试 |
+
+> 一条红线：不要让向量库承载全部多模原始数据和长期冷数据。物理存档交给 MinIO + Iceberg，向量库只做热检索面。
+
+## 4. 降本手段逐项拆解
+
+1. SHA-256 内容寻址去重：同一份附件多个会话只存一次（`core/assets.py`）。
+2. JSONL 与 Parquet/Zstd 占用对比：同一份元数据两种序列化，量化压缩收益。
+3. 按租户 / 日期 / 模态 / 冷热组织数据：分区键对齐检索与裁剪（`core/tiering.py`）。
+4. 冷热分层：原始对象和历史数据留在湖仓，不进热索引。
+5. 按需索引：只把热模态和高价值派生文本写入 seekdb。
+6. Embedding 降本：结果缓存、批量请求、失败重试（`core/embedding.py`）。
+
+其中冷热分层对应共建任务 [#32（长期记忆的存储成本控制）](https://github.com/datawhalechina/easy-data-x-ai/issues/32)，下面的多租户隔离对应 [#33（多用户记忆隔离）](https://github.com/datawhalechina/easy-data-x-ai/issues/33)。
+
+### 多租户隔离的工程实践
+
+D4 的 `d4_5_multi_user_isolation` 在单机上用内存结构做过用户隔离，到了湖仓规模，隔离要落在三个层面上：
+
+- 湖仓表：`tenant` 是 Iceberg 分区键之一（`tier / tenant / dt`）。查询时带上租户谓词，分区裁剪会直接跳过其他租户的数据文件，误读在物理层面就不会发生（`core/tiering.py` 的 `partition_key` / `filter_expression`）。
+- 热索引：seekdb 的每条索引都带 `tenant` 元数据（`build_index.py`），检索时用标量过滤限定租户，和 D4 的做法一致。
+- 对象层：这里有个容易踩的坑。内容寻址去重是跨租户的，两个租户上传同一份附件时物理只存一份。省空间没错，但访问控制就不能建在物理对象上，必须建在清单（manifest）的引用记录上：谁能访问哪条引用，由清单表里的 `tenant` 字段决定，而不是由对象存在与否决定（`core/assets.py` 的 `ObjectEntry.source` 记录了每条引用的归属）。如果租户间要求彻底的物理隔离（比如合规场景），去重范围就得退到租户内，用空间换隔离强度。
+
+## 5. 动手实验：从数据生成到 RAG 全链路
+
+配套代码在 `code/X4`（完整命令见 [code/X4/README](../code/X4/README.md)）。
+
+**Step 0 — 纯函数单测（无需任何服务，CI 即此）**
+```bash
+PYTHONPATH=code python3 -m unittest discover -s code/X4/tests -t code
+```
+
+**Step 1 — 启动 Spark 集群（严格编排）**
+```bash
+docker compose -f code/X4/docker-compose.yml up -d --build
+docker compose -f code/X4/docker-compose.yml run --rm init-minio
+```
+
+**Step 2 — 生成两档数据（固定种子可复现）**
+```bash
+python3 -m X4.spark_jobs.gen_data --tier smoke       # ≈100MB
+python3 -m X4.spark_jobs.gen_data --tier benchmark  # ≈2GB
+```
+
+**Step 3 — 写 Iceberg + 建索引 + 查询**
+```bash
+docker compose -f code/X4/docker-compose.yml exec spark-submit \
+  spark-submit --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.5.2 \
+    --master spark://spark-master:7077 \
+    spark_jobs/write_iceberg.py --table x4.agent_objects
+```
+
+**Step 4 — benchmark（基线 vs 优化）**
+```bash
+python3 -m X4.spark_jobs.benchmark --tier smoke
+```
+
+## 6. 可复现实验与指标定义
+
+每个指标都说明「测什么 + 怎么测」，并落在 `spark_jobs/benchmark.py` 与 `query.py`；`benchmark` 档真实场景均可复现，`smoke` 档本地纯 Python 就能出数。
+
+| 指标 | 类别 | 怎样测量 |
+|------|------|---------|
+| 原始对象 / 去重后字节 | 存储 | `core/assets.py` 内容寻址记账 |
+| JSONL 与 Parquet/Zstd 占用 | 存储 | 同元数据两种序列化对比 |
+| Iceberg 元数据开销 | 存储 | 表仓库 `.metadata` 目录大小 |
+| 全量 vs 按需索引条数与目录大小 | 索引 | seekdb 目录字节 + 向量条数 |
+| Embedding 请求数 / Token | Embedding | `core/embedding.py` 的 `stats` |
+| 热查询 p50 / p95 与 Hit@K | 检索质量 | `spark_jobs/query.py` 只扫热检索面 |
+| 冷查询扫描文件/字节、回温时间 | 冷层代价 | `cold_query` 的（首次访问变慢） |
+
+> **实测（本地可复现）**。分两层：对象层去重（MinIO 原始对象）和湖仓压缩（Iceberg 表）。
 >
-> 详细大纲待共建者与维护者一起对齐后补充。
+> （a）纯函数 smoke（`code/X4/spark_jobs/benchmark.py`），验证链路逻辑和去重记账：
+>
+> ```
+> === X4 benchmark(smoke) ===
+>   原始对象字节(raw): 3000
+>   去重后字节: 420
+>   JSONL 元数据字节: 4295
+>   Parquet 字节: 0
+>   Parquet+Zstd 字节: 0
+>   Iceberg 元数据开销: 0
+>   seekdb 索引目录字节: 672
+>   Embedding 请求次数: 21
+>   Embedding Token 用量: 137
+>   -> 去重比 0.86, 索引条目 21
+> ```
+>
+> （b）真实湖仓链路（`real_iceberg_bench.py`，Spark local → Iceberg，底层 MinIO）。
+>
+> **对象层去重**（`gen_data` 用 3 租户加固定共享池，模拟同一附件跨会话复用；smoke 档原始总量 ≈99.5 MiB）：
+>
+> | 度量 | 数值 |
+> |------|------|
+> | 唯一对象数 | 1979 |
+> | 原始总字节 | 104,348,219 B（≈99.5 MiB） |
+> | 去重省下字节 | 2,543,139 B（≈2.4 MiB） |
+> | 去重比 | 0.024（616 次重复引用） |
+>
+> **benchmark 档**（同一命令 `--tier benchmark`，实测原始总量 ≈1966 MiB ≈ 2GB）：唯一对象 36,072 个，去重省下 50,778,500 B（≈48.4 MiB），去重比 0.025。
+>
+> **湖仓压缩**（50 万行分区表，分区键 `tier / tenant / dt`）：
+>
+> | 度量 | 数值 |
+> |------|------|
+> | Iceberg data（Parquet）体积 | 1.6 MiB |
+> | Iceberg `.metadata` 开销 | 15 KiB |
+> | 文件数 | 13 |
+> | 等量 JSONL 体积 | ≈15.6 MiB |
+> | JSONL → Parquet 压缩比 | ≈9.6× |
+> | 分区剪裁 `tier='hot'` | 命中 200000 |
+> | 分区剪裁 `tier='warm'` | 命中 200000 |
+> | 分区剪裁 `tier='cold'` | 命中 100000 |
+>
+> 复现命令（禁代理直连本地 MinIO）：
+> ```bash
+> env -u http_proxy -u https_proxy PYTHONPATH=code .venv/bin/python \
+>   code/X4/spark_jobs/real_iceberg_bench.py 500000
+> ```
+> 该脚本用 Spark 本地引擎 + MinIO（S3）完成 Iceberg 写表、元数据统计与分区裁剪，输出上表。benchmark 档（约 2GB）在同一命令换更大 N 即可扩展。
 
-## 如何参与共建
+## 7. 关联与延伸
 
-本章节欢迎你来认领、撰写。完整的参与方式、任务列表与激励机制，请阅读：
+D4 的 `d4_7_hot_cold_tier` 在单机上演示过冷热分层，`d4_5_multi_user_isolation` 演示过多用户隔离，本章把两者搬到了真实的 MinIO + Iceberg 湖仓上：冷热变成分区键，租户隔离变成 `tenant` 分区加清单层访问控制。D2 讲过的混合检索和 Embedding，在这里接上了湖仓这个上游，凑成完整的「湖 → RAG」链路。对应的共建任务是 [#32](https://github.com/datawhalechina/easy-data-x-ai/issues/32)（存储成本控制）和 [#33](https://github.com/datawhalechina/easy-data-x-ai/issues/33)（多用户记忆隔离）。
 
-👉 **[贡献指南 CONTRIBUTING.md](https://github.com/datawhalechina/easy-data-x-ai/blob/main/CONTRIBUTING.md)**
+## 8. 总结
 
-- 扩展篇方向较大，**认领前请先开 [Issue](https://github.com/datawhalechina/easy-data-x-ai/issues) 对齐内容大纲**。
-- 完成后提交 PR，即可登上仓库[贡献者墙](https://github.com/datawhalechina/easy-data-x-ai#-贡献者墙)并获得社区激励。
+回到开头那句话：湖管全量和冷，向量库管热和检索。去重、冷热分层、按需索引、Embedding 缓存这四件事都不复杂，难的是把它们串成一条可验证的链路。本章的全部数字都能用固定种子和两档数据在你自己机器上重跑出来；如果跑出了不一样的结果，欢迎到 Issue 里聊。
+
+> 本节为 Datawhale《Easy Data x AI》扩展篇 X4，认领 Issue `#39` / 任务 `#96`。欢迎在 Issue 下交流与共建。

--- a/docs/extra/X4 海量 AI Agent 多模数据降本：数据湖库登场.md
+++ b/docs/extra/X4 海量 AI Agent 多模数据降本：数据湖库登场.md
@@ -98,7 +98,7 @@ D4 的 `d4_5_multi_user_isolation` 在单机上用内存结构做过用户隔离
 
 ## 5. 动手实验：从数据生成到 RAG 全链路
 
-配套代码在 `code/X4`（完整命令见 [code/X4/README](../code/X4/README.md)）。
+配套代码在 `code/X4`（完整命令见 [code/X4/README](https://github.com/datawhalechina/easy-data-x-ai/tree/main/code/X4/README.md)）。
 
 **Step 0 — 纯函数单测（无需任何服务，CI 即此）**
 ```bash


### PR DESCRIPTION
认领 Issue #39（任务 #96），提交扩展篇 X4 的正文和配套代码。

Closes #39
Related to #32 #33

## 做了什么

- `docs/extra/` 下的 X4 占位页替换为完整成稿，讲海量多模数据场景下
  用 MinIO + Iceberg 湖仓做降本，再接回 seekdb 完成「湖 → RAG」链路
- 新增 `code/X4/`，是一套可复现的实验代码：
  - `core/`：内容寻址去重、Embedding 缓存/批量/重试、冷热分层规则、成本指标统计
  - `spark_jobs/`：固定种子（seed=42）的数据生成、Iceberg 分区写入、
    按需索引、冷热查询、基线对比基准，以及真实 Spark + Iceberg + MinIO 的压测脚本
  - `tests/`：26 个纯 Python 单元测试，不依赖 Docker，已接入 `code/run_tests.py`
- 导航里 X4 条目去掉「共建中」标记；`.gitignore` 忽略 `jars/` 和 `spark-warehouse/`
  （Iceberg 运行时 jar 约 300MB，README 里给了 Maven 下载命令）

## 实测数据

数据生成固定种子，克隆后可复现同样的结果：

| 档位 | 体积 | 唯一对象数 | 去重节省 |
|---|---|---|---|
| smoke | ≈99.5 MiB | 1,979 | 2.4% |
| benchmark | ≈1,966 MiB | 36,072 | 2.5% |

真实湖仓压测（10 万行元数据）：Parquet/Zstd 落盘 2.0 MiB，
对比 JSONL 压缩比约 9.6×；tier/tenant/dt 三级分区裁剪验证通过。

## 与正文的关联

D4 的 d4_7（冷热分层）和 d4_5（多用户隔离）是单机版演示，本章把两者搬到
湖仓规模：冷热变成分区键，租户隔离落在分区裁剪、索引元数据过滤和清单层
访问控制三个层面。分别对应共建任务 #32 和 #33。

## 验证

- `PYTHONPATH=code python code/run_tests.py`：全仓 266 个测试通过
- smoke 和 benchmark 两档端到端跑通（gen_data → write_iceberg → build_index → query → benchmark）