### PR TITLE
fix: 修复 X1-3 的 D4 链接 URL 编码截断与 P1 的 OpenClaw 仓库地址（404）

### DIFF
--- a/docs/extra/X1-3 从记忆到认知.md
+++ b/docs/extra/X1-3 从记忆到认知.md
@@ -311,7 +311,7 @@ X1 系列三篇形成完整逻辑链：
 
 **参考资料：**
 
-1. [D4 Agent 开发与记忆系统](https://datawhalechina.github.io/easy-data-x-ai/dev/D4%20%E8%AF%BE%E7%A8%8BF%EF%BC%9AAgent%20%E5%BC%80%E5%8F%91%E4%B8%8E%E8%AE%B0%E5%BF%86%E7%B3%BB%E7%BB%9F.html)
+1. [D4 Agent 开发与记忆系统](https://datawhalechina.github.io/easy-data-x-ai/dev/D4%20%E8%AF%BE%E7%A8%8B%E7%A8%BF%EF%BC%9AAgent%20%E5%BC%80%E5%8F%91%E4%B8%8E%E8%AE%B0%E5%BF%86%E7%B3%BB%E7%BB%9F.html)
 2. CoALA — [arxiv.org/abs/2309.02427](https://arxiv.org/abs/2309.02427)
 3. LOCOMO Benchmark — [snap-research/locomo](https://github.com/snap-research/locomo)
 4. [P4 Skill 与 Agent 知识管理](https://datawhalechina.github.io/easy-data-x-ai/pm/P4%20%E8%AF%BE%E7%A8%8B%E7%A8%BF%EF%BC%9ASkill%20%E4%B8%8E%20Agent%20%E7%9F%A5%E8%AF%86%E7%AE%A1%E7%90%86.html)

--- a/docs/pm/P1 课程稿：AI Agent 场景识别.md
+++ b/docs/pm/P1 课程稿：AI Agent 场景识别.md
@@ -407,7 +407,7 @@ Agent 能做的是：理解“去美国出差”这个模糊意图，主动判�
 
 传统方案是云端 SaaS——用户通过网页或 App 使用你的 AI 服务。但 2025 年底开始，一个新的趋势正在出现：**本地 Agent**。
 
-代表项目是 [OpenClaw](https://github.com/101dotxyz/OpenClaw)——一个开源的自主 AI Agent，完全在用户本地设备上运行，数据不出本地，可以 7×24 小时自主执行任务。
+代表项目是 [OpenClaw](https://github.com/openclaw/openclaw)——一个开源的自主 AI Agent，完全在用户本地设备上运行，数据不出本地，可以 7×24 小时自主执行任务。
 
 从产品决策角度看，本地 Agent 解决了一个核心问题：**数据隐私与信任**。
 


### PR DESCRIPTION
## 问题

对全仓库 46 个 markdown 文件做链接审计后，发现两处真实死链（其余为 B 站反爬 412 误报、VitePress public 目录映射等假阳性，已逐一排除）：

### 1. `docs/extra/X1-3 从记忆到认知.md` L314 — D4 链接编码截断

```markdown
[D4 Agent 开发与记忆系统](https://datawhalechina.github.io/easy-data-x-ai/dev/D4%20%E8%AF%BE%E7%A8%8BF%EF%BC%9A...)
```

URL 中「稿」字的百分号编码 `%E7%A8%BF` 被截断成孤立的 `F`，整条链接解码成「D4 课程**F**：Agent 开发与记忆系统」，实际访问 **404**。

同文件 L317 的 P4 链接编码是完整的（`%E8%AF%BE%E7%A8%8B%E7%A8%BF%EF%BC%9A`），两者对比可清晰看到 `稿`（`%E7%A8%BF`）的编码在 D4 链接中丢失了 `%E7%A8`，只剩尾字符 `F`。

修复：补全为正确编码后实测 **200**。

### 2. `docs/pm/P1 课程稿：AI Agent 场景识别.md` L410 — OpenClaw 仓库地址错误

```markdown
[OpenClaw](https://github.com/101dotxyz/OpenClaw)
```

`101dotxyz/OpenClaw` 不存在（404）。该项目真实地址为 [openclaw/openclaw](https://github.com/openclaw/openclaw)（38.6k+ stars 的开源本地 AI Agent），与文中「完全在用户本地设备上运行、数据不出本地」的描述一致。

## 修改

| 文件 | 改动 |
|------|------|
| `docs/extra/X1-3 从记忆到认知.md` | 1 处 URL 编码修复 |
| `docs/pm/P1 课程稿：AI Agent 场景识别.md` | 1 处仓库地址修复 |

均为最小改动，不影响正文内容。