### PR TITLE
fix: 合并统计 PR 与 commit 作者生成贡献者墙

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Check documentation references
         run: npm run docs:check
 
+      - name: Test contributor wall
+        run: npm run contributors:test
+
       - name: Build docs
         run: npm run docs:build
 

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -8,6 +8,11 @@ on:
 
 permissions:
   contents: write
+  pull-requests: read
+
+concurrency:
+  group: update-contributors-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   update:
@@ -23,6 +28,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24
+
+      - name: Test contributor wall
+        run: npm run contributors:test
 
       - name: Refresh contributor wall
         env:

--- a/README.md
+++ b/README.md
@@ -274,56 +274,56 @@ python code/D1/d1_1_base.py
     <img src="https://avatars.githubusercontent.com/u/13233790?v=4&s=144" width="72" height="72" alt="liboyang0730" style="border-radius:50%;" />
   </a><br />
   <a href="https://github.com/liboyang0730" title="打开 liboyang0730 的 GitHub 主页"><kbd><strong>liboyang073…</strong></kbd></a><br />
-  <sub>112 commits</sub>
+  <sub>112 commits<br />13 merged PRs</sub>
 </td>
 <td align="center" valign="top" width="104">
   <a href="https://github.com/Kratos-Lee" title="Kratos-Lee">
     <img src="https://avatars.githubusercontent.com/u/180283969?v=4&s=144" width="72" height="72" alt="Kratos-Lee" style="border-radius:50%;" />
   </a><br />
   <a href="https://github.com/Kratos-Lee" title="打开 Kratos-Lee 的 GitHub 主页"><kbd><strong>Kratos‑Lee</strong></kbd></a><br />
-  <sub>22 commits</sub>
+  <sub>22 commits<br />11 merged PRs</sub>
 </td>
 <td align="center" valign="top" width="104">
   <a href="https://github.com/knqiufan" title="knqiufan">
     <img src="https://avatars.githubusercontent.com/u/34114995?v=4&s=144" width="72" height="72" alt="knqiufan" style="border-radius:50%;" />
   </a><br />
   <a href="https://github.com/knqiufan" title="打开 knqiufan 的 GitHub 主页"><kbd><strong>knqiufan</strong></kbd></a><br />
-  <sub>20 commits</sub>
+  <sub>20 commits<br />14 merged PRs</sub>
 </td>
 <td align="center" valign="top" width="104">
   <a href="https://github.com/haoye2" title="haoye2">
     <img src="https://avatars.githubusercontent.com/u/199622891?v=4&s=144" width="72" height="72" alt="haoye2" style="border-radius:50%;" />
   </a><br />
   <a href="https://github.com/haoye2" title="打开 haoye2 的 GitHub 主页"><kbd><strong>haoye2</strong></kbd></a><br />
-  <sub>6 commits</sub>
+  <sub>6 commits<br />6 merged PRs</sub>
 </td>
 <td align="center" valign="top" width="104">
   <a href="https://github.com/Terminator666666" title="Terminator666666">
     <img src="https://avatars.githubusercontent.com/u/104662484?v=4&s=144" width="72" height="72" alt="Terminator666666" style="border-radius:50%;" />
   </a><br />
   <a href="https://github.com/Terminator666666" title="打开 Terminator666666 的 GitHub 主页"><kbd><strong>Terminator6…</strong></kbd></a><br />
-  <sub>2 commits</sub>
+  <sub>2 commits<br />1 merged PR</sub>
 </td>
 <td align="center" valign="top" width="104">
   <a href="https://github.com/amber-moe" title="amber-moe">
     <img src="https://avatars.githubusercontent.com/u/42762957?v=4&s=144" width="72" height="72" alt="amber-moe" style="border-radius:50%;" />
   </a><br />
   <a href="https://github.com/amber-moe" title="打开 amber-moe 的 GitHub 主页"><kbd><strong>amber‑moe</strong></kbd></a><br />
-  <sub>1 commit</sub>
+  <sub>1 commit<br />1 merged PR</sub>
 </td>
 <td align="center" valign="top" width="104">
   <a href="https://github.com/hu-qi" title="hu-qi">
     <img src="https://avatars.githubusercontent.com/u/17986122?v=4&s=144" width="72" height="72" alt="hu-qi" style="border-radius:50%;" />
   </a><br />
   <a href="https://github.com/hu-qi" title="打开 hu-qi 的 GitHub 主页"><kbd><strong>hu‑qi</strong></kbd></a><br />
-  <sub>1 commit</sub>
+  <sub>1 commit<br />1 merged PR</sub>
 </td>
 <td align="center" valign="top" width="104">
   <a href="https://github.com/Iridescent115" title="Iridescent115">
     <img src="https://avatars.githubusercontent.com/u/209439429?v=4&s=144" width="72" height="72" alt="Iridescent115" style="border-radius:50%;" />
   </a><br />
   <a href="https://github.com/Iridescent115" title="打开 Iridescent115 的 GitHub 主页"><kbd><strong>Iridescent1…</strong></kbd></a><br />
-  <sub>1 commit</sub>
+  <sub>1 commit<br />1 merged PR</sub>
 </td>
 </tr>
 <tr>
@@ -332,42 +332,49 @@ python code/D1/d1_1_base.py
     <img src="https://avatars.githubusercontent.com/u/43478980?v=4&s=144" width="72" height="72" alt="JasonZhang10086" style="border-radius:50%;" />
   </a><br />
   <a href="https://github.com/JasonZhang10086" title="打开 JasonZhang10086 的 GitHub 主页"><kbd><strong>JasonZhang1…</strong></kbd></a><br />
-  <sub>1 commit</sub>
+  <sub>1 commit<br />1 merged PR</sub>
 </td>
 <td align="center" valign="top" width="104">
   <a href="https://github.com/jay666mnj" title="jay666mnj">
     <img src="https://avatars.githubusercontent.com/u/192066339?v=4&s=144" width="72" height="72" alt="jay666mnj" style="border-radius:50%;" />
   </a><br />
   <a href="https://github.com/jay666mnj" title="打开 jay666mnj 的 GitHub 主页"><kbd><strong>jay666mnj</strong></kbd></a><br />
-  <sub>1 commit</sub>
+  <sub>1 commit<br />1 merged PR</sub>
 </td>
 <td align="center" valign="top" width="104">
   <a href="https://github.com/ksk2023" title="ksk2023">
     <img src="https://avatars.githubusercontent.com/u/154514711?v=4&s=144" width="72" height="72" alt="ksk2023" style="border-radius:50%;" />
   </a><br />
   <a href="https://github.com/ksk2023" title="打开 ksk2023 的 GitHub 主页"><kbd><strong>ksk2023</strong></kbd></a><br />
-  <sub>1 commit</sub>
+  <sub>1 commit<br />1 merged PR</sub>
 </td>
 <td align="center" valign="top" width="104">
   <a href="https://github.com/oiahoon" title="oiahoon">
     <img src="https://avatars.githubusercontent.com/u/4361724?v=4&s=144" width="72" height="72" alt="oiahoon" style="border-radius:50%;" />
   </a><br />
   <a href="https://github.com/oiahoon" title="打开 oiahoon 的 GitHub 主页"><kbd><strong>oiahoon</strong></kbd></a><br />
-  <sub>1 commit</sub>
+  <sub>1 commit<br />1 merged PR</sub>
 </td>
 <td align="center" valign="top" width="104">
   <a href="https://github.com/pzb5471" title="pzb5471">
     <img src="https://avatars.githubusercontent.com/u/77824109?v=4&s=144" width="72" height="72" alt="pzb5471" style="border-radius:50%;" />
   </a><br />
   <a href="https://github.com/pzb5471" title="打开 pzb5471 的 GitHub 主页"><kbd><strong>pzb5471</strong></kbd></a><br />
-  <sub>1 commit</sub>
+  <sub>1 commit<br />1 merged PR</sub>
 </td>
 <td align="center" valign="top" width="104">
   <a href="https://github.com/webup" title="webup">
     <img src="https://avatars.githubusercontent.com/u/2936504?v=4&s=144" width="72" height="72" alt="webup" style="border-radius:50%;" />
   </a><br />
   <a href="https://github.com/webup" title="打开 webup 的 GitHub 主页"><kbd><strong>webup</strong></kbd></a><br />
-  <sub>1 commit</sub>
+  <sub>1 commit<br />1 merged PR</sub>
+</td>
+<td align="center" valign="top" width="104">
+  <a href="https://github.com/LINxiansheng" title="LINxiansheng">
+    <img src="https://avatars.githubusercontent.com/u/18351861?v=4&s=144" width="72" height="72" alt="LINxiansheng" style="border-radius:50%;" />
+  </a><br />
+  <a href="https://github.com/LINxiansheng" title="打开 LINxiansheng 的 GitHub 主页"><kbd><strong>LINxianshen…</strong></kbd></a><br />
+  <sub>4 merged PRs</sub>
 </td>
 </tr>
 </table>

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs",
+    "contributors:test": "node --test scripts/contributors-data.test.mjs scripts/contributor-wall.test.mjs",
     "contributors:update": "node scripts/update-contributors.mjs"
   },
   "dependencies": {

--- a/scripts/contributor-wall.mjs
+++ b/scripts/contributor-wall.mjs
@@ -21,6 +21,19 @@ export function buildWall(contributors) {
     // (e.g. "xschen-beb"): U+2011 non-breaking hyphen + &nbsp;. Truncation
     // above is then the single, uniform overflow rule.
     const noWrapLogin = displayedLogin.replace(/-/g, '‑').replace(/ /g, '&nbsp;');
+    const contributionLines = [];
+
+    if (contributor.commitCount > 0) {
+      contributionLines.push(
+        `${contributor.commitCount} commit${contributor.commitCount === 1 ? '' : 's'}`,
+      );
+    }
+
+    if (contributor.mergedPrCount > 0) {
+      contributionLines.push(
+        `${contributor.mergedPrCount} merged PR${contributor.mergedPrCount === 1 ? '' : 's'}`,
+      );
+    }
 
     return [
       '<td align="center" valign="top" width="104">',
@@ -28,7 +41,7 @@ export function buildWall(contributors) {
       `    <img src="${contributor.avatarUrl}" width="72" height="72" alt="${contributor.login}" style="border-radius:50%;" />`,
       '  </a><br />',
       `  <a href="${contributor.profileUrl}" title="打开 ${contributor.login} 的 GitHub 主页"><kbd><strong>${noWrapLogin}</strong></kbd></a><br />`,
-      `  <sub>${contributor.contributions} commit${contributor.contributions === 1 ? '' : 's'}</sub>`,
+      `  <sub>${contributionLines.join('<br />')}</sub>`,
       '</td>',
     ].join('\n');
   });

--- a/scripts/contributor-wall.test.mjs
+++ b/scripts/contributor-wall.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildWall } from './contributor-wall.mjs';
+
+test('为仅有已合并 PR 的贡献者显示 PR 数量', () => {
+  const wall = buildWall([
+    {
+      login: 'LINxiansheng',
+      profileUrl: 'https://github.com/LINxiansheng',
+      avatarUrl: 'https://avatars.githubusercontent.com/u/18351861?v=4&s=144',
+      commitCount: 0,
+      mergedPrCount: 3,
+    },
+  ]);
+
+  assert.match(wall, /title="LINxiansheng"/);
+  assert.match(wall, /3 merged PRs/);
+  assert.doesNotMatch(wall, /0 commits/);
+});
+
+test('同时显示提交与已合并 PR 数量并处理单复数', () => {
+  const wall = buildWall([
+    {
+      login: 'same-author',
+      profileUrl: 'https://github.com/same-author',
+      avatarUrl: 'https://avatars.githubusercontent.com/u/42?v=4&s=144',
+      commitCount: 1,
+      mergedPrCount: 1,
+    },
+  ]);
+
+  assert.match(wall, /<sub>1 commit<br \/>1 merged PR<\/sub>/);
+});

--- a/scripts/contributors-data.mjs
+++ b/scripts/contributors-data.mjs
@@ -1,0 +1,105 @@
+const PAGE_SIZE = 100;
+
+function contributorKey(user) {
+  return user.id ? `user:${user.id}` : `login:${user.login.toLowerCase()}`;
+}
+
+function ensureContributor(byUser, user) {
+  const key = contributorKey(user);
+  const existing = byUser.get(key);
+  if (existing) {
+    return existing;
+  }
+
+  const contributor = {
+    login: user.login,
+    profileUrl: user.html_url,
+    avatarUrl: `${user.avatar_url}${user.avatar_url.includes('?') ? '&' : '?'}s=144`,
+    commitCount: 0,
+    mergedPrCount: 0,
+  };
+  byUser.set(key, contributor);
+  return contributor;
+}
+
+async function requestPage(url, { fetchImpl, headers }) {
+  const response = await fetchImpl(url, { headers });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`GitHub API ${response.status} ${response.statusText}: ${body}`);
+  }
+
+  const items = await response.json();
+  if (!Array.isArray(items)) {
+    throw new Error(`GitHub API 返回了无效列表：${url}`);
+  }
+
+  return items;
+}
+
+async function fetchAllPages(url, options) {
+  const items = [];
+
+  for (let page = 1; ; page += 1) {
+    const separator = url.includes('?') ? '&' : '?';
+    const pageItems = await requestPage(
+      `${url}${separator}per_page=${PAGE_SIZE}&page=${page}`,
+      options,
+    );
+    items.push(...pageItems);
+
+    if (pageItems.length < PAGE_SIZE) {
+      return items;
+    }
+  }
+}
+
+export async function fetchContributors(
+  repoSlug,
+  {
+    fetchImpl = fetch,
+    token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN,
+  } = {},
+) {
+  const headers = {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'easy-data-x-ai-contributor-wall',
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  const apiRoot = `https://api.github.com/repos/${repoSlug}`;
+  const [commits, pulls] = await Promise.all([
+    fetchAllPages(`${apiRoot}/commits`, { fetchImpl, headers }),
+    fetchAllPages(
+      `${apiRoot}/pulls?state=closed&sort=created&direction=asc`,
+      { fetchImpl, headers },
+    ),
+  ]);
+  const byUser = new Map();
+
+  for (const commit of commits) {
+    const author = commit?.author;
+    if (!author?.login || author.type !== 'User') {
+      continue;
+    }
+
+    ensureContributor(byUser, author).commitCount += 1;
+  }
+
+  for (const pull of pulls) {
+    const author = pull?.user;
+    if (!pull?.merged_at || !author?.login || author.type !== 'User') {
+      continue;
+    }
+
+    ensureContributor(byUser, author).mergedPrCount += 1;
+  }
+
+  return [...byUser.values()].sort(
+    (a, b) => b.commitCount - a.commitCount
+      || b.mergedPrCount - a.mergedPrCount
+      || a.login.localeCompare(b.login),
+  );
+}

--- a/scripts/contributors-data.test.mjs
+++ b/scripts/contributors-data.test.mjs
@@ -1,0 +1,165 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { fetchContributors } from './contributors-data.mjs';
+
+function githubUser({ id, login, type = 'User' }) {
+  return {
+    id,
+    login,
+    type,
+    html_url: `https://github.com/${login}`,
+    avatar_url: `https://avatars.githubusercontent.com/u/${id}?v=4`,
+  };
+}
+
+function createFetch({ commits = [], pulls = [], commitPages, pullPages }) {
+  return async (input) => {
+    const url = new URL(input);
+    const page = Number(url.searchParams.get('page'));
+
+    if (url.pathname.endsWith('/commits')) {
+      return Response.json(commitPages?.[page - 1] ?? commits);
+    }
+
+    if (url.pathname.endsWith('/pulls')) {
+      return Response.json(pullPages?.[page - 1] ?? pulls);
+    }
+
+    throw new Error(`未预期的 GitHub API 请求：${url}`);
+  };
+}
+
+test('提交邮箱未关联时仍通过已合并 PR 收录作者', async () => {
+  const lin = githubUser({ id: 18351861, login: 'LINxiansheng' });
+  const fetchImpl = createFetch({
+    commits: [{ sha: 'unlinked', author: null }],
+    pulls: [
+      {
+        number: 100,
+        merged_at: '2026-09-02T06:17:29Z',
+        user: lin,
+      },
+    ],
+  });
+
+  const contributors = await fetchContributors('datawhalechina/easy-data-x-ai', {
+    fetchImpl,
+  });
+
+  assert.deepEqual(contributors, [
+    {
+      login: 'LINxiansheng',
+      profileUrl: 'https://github.com/LINxiansheng',
+      avatarUrl: 'https://avatars.githubusercontent.com/u/18351861?v=4&s=144',
+      commitCount: 0,
+      mergedPrCount: 1,
+    },
+  ]);
+});
+
+test('完整读取提交与已关闭 PR 的后续分页', async () => {
+  const directAuthor = githubUser({ id: 1, login: 'direct-author' });
+  const lin = githubUser({ id: 18351861, login: 'LINxiansheng' });
+  const fetchImpl = createFetch({
+    commitPages: [
+      Array.from({ length: 100 }, (_, index) => ({
+        sha: `commit-${index}`,
+        author: directAuthor,
+      })),
+      [{ sha: 'commit-100', author: directAuthor }],
+    ],
+    pullPages: [
+      Array.from({ length: 100 }, (_, index) => ({
+        number: index + 1,
+        merged_at: null,
+        user: lin,
+      })),
+      [{ number: 101, merged_at: '2026-09-02T06:17:29Z', user: lin }],
+    ],
+  });
+
+  const contributors = await fetchContributors('datawhalechina/easy-data-x-ai', {
+    fetchImpl,
+  });
+
+  assert.deepEqual(
+    contributors.map(({ login, commitCount, mergedPrCount }) => ({
+      login,
+      commitCount,
+      mergedPrCount,
+    })),
+    [
+      { login: 'direct-author', commitCount: 101, mergedPrCount: 0 },
+      { login: 'LINxiansheng', commitCount: 0, mergedPrCount: 1 },
+    ],
+  );
+});
+
+test('同一 GitHub 用户的提交与已合并 PR 合并为一条记录', async () => {
+  const author = githubUser({ id: 42, login: 'same-author' });
+  const fetchImpl = createFetch({
+    commits: [{ sha: 'commit-1', author }],
+    pulls: [
+      { number: 1, merged_at: '2026-09-02T01:00:00Z', user: author },
+      { number: 2, merged_at: '2026-09-02T02:00:00Z', user: author },
+    ],
+  });
+
+  const contributors = await fetchContributors('datawhalechina/easy-data-x-ai', {
+    fetchImpl,
+  });
+
+  assert.equal(contributors.length, 1);
+  assert.deepEqual(
+    {
+      login: contributors[0].login,
+      commitCount: contributors[0].commitCount,
+      mergedPrCount: contributors[0].mergedPrCount,
+    },
+    { login: 'same-author', commitCount: 1, mergedPrCount: 2 },
+  );
+});
+
+test('忽略 Bot、删除账号以及未合并的 PR', async () => {
+  const bot = githubUser({ id: 99, login: 'automation[bot]', type: 'Bot' });
+  const human = githubUser({ id: 100, login: 'not-merged' });
+  const fetchImpl = createFetch({
+    commits: [
+      { sha: 'unlinked', author: null },
+      { sha: 'bot', author: bot },
+    ],
+    pulls: [
+      { number: 1, merged_at: '2026-09-02T01:00:00Z', user: null },
+      { number: 2, merged_at: '2026-09-02T02:00:00Z', user: bot },
+      { number: 3, merged_at: null, user: human },
+    ],
+  });
+
+  const contributors = await fetchContributors('datawhalechina/easy-data-x-ai', {
+    fetchImpl,
+  });
+
+  assert.deepEqual(contributors, []);
+});
+
+test('任一 GitHub API 请求失败时不返回部分结果', async () => {
+  const author = githubUser({ id: 1, login: 'direct-author' });
+  const fetchImpl = async (input) => {
+    const url = new URL(input);
+
+    if (url.pathname.endsWith('/commits')) {
+      return Response.json([{ sha: 'commit-1', author }]);
+    }
+
+    return new Response('pull request access denied', {
+      status: 403,
+      statusText: 'Forbidden',
+    });
+  };
+
+  await assert.rejects(
+    fetchContributors('datawhalechina/easy-data-x-ai', { fetchImpl }),
+    /GitHub API 403 Forbidden: pull request access denied/,
+  );
+});

--- a/scripts/update-contributors.mjs
+++ b/scripts/update-contributors.mjs
@@ -3,6 +3,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import { buildWall } from './contributor-wall.mjs';
+import { fetchContributors } from './contributors-data.mjs';
 
 const rootDir = resolve(import.meta.dirname, '..');
 const readmePath = resolve(rootDir, 'README.md');
@@ -25,67 +26,6 @@ function resolveRepoSlug() {
   }
 
   return match[1];
-}
-
-// Aggregate contributors from the commits API rather than the /contributors
-// stats endpoint. The latter is cached/eventually-consistent: after pushes it
-// can return a transitional snapshot that omits real contributors or surfaces
-// bots, which would silently drop people from the wall. Tallying commit authors
-// is authoritative and real-time.
-async function fetchContributors(repoSlug) {
-  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
-  const headers = {
-    Accept: 'application/vnd.github+json',
-    'User-Agent': 'easy-data-x-ai-contributor-wall',
-  };
-
-  if (token) {
-    headers.Authorization = `Bearer ${token}`;
-  }
-
-  const byLogin = new Map();
-  let page = 1;
-
-  while (true) {
-    const url = `https://api.github.com/repos/${repoSlug}/commits?per_page=100&page=${page}`;
-    const response = await fetch(url, { headers });
-
-    if (!response.ok) {
-      const body = await response.text();
-      throw new Error(`GitHub API ${response.status} ${response.statusText}: ${body}`);
-    }
-
-    const pageItems = await response.json();
-    if (!Array.isArray(pageItems) || pageItems.length === 0) {
-      break;
-    }
-
-    for (const commit of pageItems) {
-      const author = commit?.author;
-      // Skip commits with no linked GitHub user (e.g. unmatched email) and bots.
-      if (!author?.login || author.type !== 'User') {
-        continue;
-      }
-
-      const existing = byLogin.get(author.login);
-      if (existing) {
-        existing.contributions += 1;
-      } else {
-        byLogin.set(author.login, {
-          login: author.login,
-          profileUrl: author.html_url,
-          avatarUrl: `${author.avatar_url}&s=144`,
-          contributions: 1,
-        });
-      }
-    }
-
-    page += 1;
-  }
-
-  return [...byLogin.values()].sort(
-    (a, b) => b.contributions - a.contributions || a.login.localeCompare(b.login),
-  );
 }
 
 function updateReadme(wallMarkup) {


### PR DESCRIPTION
## 背景

README 文案承诺“所有合并过 PR 的同学都会出现在这里”，但原生成脚本只统计 GitHub 能识别账号的 commit 作者。当 commit 邮箱未关联 GitHub 账号时，即使作者已有合并 PR，也会从贡献者墙中遗漏。PR #100 的作者 `LINxiansheng` 正是这一情况。

## 改动

- 合并统计可识别的 commit 作者与已合并 PR 作者
- 按 GitHub 用户 ID 去重，并分别展示 commit 和 merged PR 数量
- 完整处理 commits、closed PR 的分页
- 过滤 Bot、删除账号与未合并 PR
- 任一 GitHub API 请求失败时停止生成，避免写入部分结果
- 为生成逻辑和渲染逻辑补充回归测试，并接入 CI
- 为更新 Action 增加只读 PR 权限及并发保护

当前实时数据生成结果中，`LINxiansheng` 已恢复显示为 `4 merged PRs`。

## 验证

- `npm run contributors:test`：7/7 通过
- `python code/run_tests.py`：266/266 通过
- `npm run docs:check`：通过
- `npm run docs:build`：通过
- README 贡献者墙与 GitHub 实时数据一致，墙外内容未变化
